### PR TITLE
Support IDE Binding class inheritance and Visual Studio csproj backward compatiblilty

### DIFF
--- a/IdeIntegration/Bindings/ILBindingRegistryBuilder.cs
+++ b/IdeIntegration/Bindings/ILBindingRegistryBuilder.cs
@@ -33,9 +33,15 @@ namespace TechTalk.SpecFlow.IdeIntegration.Bindings
                 if (!bindingSourceProcessor.ProcessType(bindingSourceType))
                     continue;
 
-                foreach (var methodDefinition in typeDefinition.Methods)
+                var type = typeDefinition;
+
+                while (type.Module == module)
                 {
-                    bindingSourceProcessor.ProcessMethod(CreateBindingSourceMethod(methodDefinition, bindingSourceType, bindingSourceProcessor));
+                    foreach (var methodDefinition in type.Methods)
+                    {
+                        bindingSourceProcessor.ProcessMethod(CreateBindingSourceMethod(methodDefinition, bindingSourceType, bindingSourceProcessor));
+                    }
+                    type = typeDefinition.BaseType.Resolve();
                 }
 
                 bindingSourceProcessor.ProcessTypeDone();

--- a/IdeIntegration/Bindings/ILBindingRegistryBuilder.cs
+++ b/IdeIntegration/Bindings/ILBindingRegistryBuilder.cs
@@ -33,15 +33,9 @@ namespace TechTalk.SpecFlow.IdeIntegration.Bindings
                 if (!bindingSourceProcessor.ProcessType(bindingSourceType))
                     continue;
 
-                var type = typeDefinition;
-
-                while (type.Module == module)
+                foreach (var methodDefinition in typeDefinition.Methods)
                 {
-                    foreach (var methodDefinition in type.Methods)
-                    {
-                        bindingSourceProcessor.ProcessMethod(CreateBindingSourceMethod(methodDefinition, bindingSourceType, bindingSourceProcessor));
-                    }
-                    type = typeDefinition.BaseType.Resolve();
+                    bindingSourceProcessor.ProcessMethod(CreateBindingSourceMethod(methodDefinition, bindingSourceType, bindingSourceProcessor));
                 }
 
                 bindingSourceProcessor.ProcessTypeDone();

--- a/ItemTemplates/TechTalk.SpecFlow.VsIntegration.ItemTemplates.csproj
+++ b/ItemTemplates/TechTalk.SpecFlow.VsIntegration.ItemTemplates.csproj
@@ -1,12 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <VSCommonExtensionsPath Condition="'$(VSCommonExtensionsPath)' == ''">$(MSBuildExtensionsPath32)\..\Microsoft Visual Studio $(VisualStudioVersion)\Common7\IDE\CommonExtensions</VSCommonExtensionsPath>
+  </PropertyGroup>
+  <!-- This is the property that causes VS 2012+ to insist on one-way update of the project -->
+  <PropertyGroup Condition="'$(VisualStudioVersion)' &gt;= '11.0'">
+    <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <!-- This is an additional property added by VS 2013 -->
+  <PropertyGroup Condition="'$(VisualStudioVersion)' &gt;= '12.0'">
+    <OldToolsVersion>4.0</OldToolsVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
-    <OldToolsVersion>12.0</OldToolsVersion>
     <UpgradeBackupLocation />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -65,9 +74,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
@@ -121,7 +128,7 @@
     <None Include="SpecFlowFeature_CSharp\SpecFlowFeature1.feature" />
     <None Include="SpecFlowFeature_VB\SpecFlowFeature1.feature" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/VsIntegration/TechTalk.SpecFlow.VsIntegration.csproj
+++ b/VsIntegration/TechTalk.SpecFlow.VsIntegration.csproj
@@ -1,419 +1,453 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
-  <PropertyGroup>
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <VSCommonExtensionsPath Condition="'$(VSCommonExtensionsPath)' == ''">$(MSBuildExtensionsPath32)\..\Microsoft Visual Studio $(VisualStudioVersion)\Common7\IDE\CommonExtensions</VSCommonExtensionsPath>
-  </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>10.0.20305</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ProjectGuid>{96294E6F-8875-4D12-8577-4EC83E60BD6C}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>TechTalk.SpecFlow.VsIntegration</RootNamespace>
-    <AssemblyName>TechTalk.SpecFlow.VsIntegration</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DeployExtension>True</DeployExtension>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DeployExtension>False</DeployExtension>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Designer.Interfaces, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Editor, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.OLE.Interop" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestWindow">
-      <HintPath>$(VSCommonExtensionsPath)\Microsoft\TestWindow\Microsoft.VisualStudio.TestWindow.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestWindow.Core">
-      <HintPath>$(VSCommonExtensionsPath)\Microsoft\TestWindow\Microsoft.VisualStudio.TestWindow.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestWindow.Interfaces">
-      <HintPath>$(VSCommonExtensionsPath)\Microsoft\TestWindow\Microsoft.VisualStudio.TestWindow.Interfaces.dll</HintPath>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.TextManager.Interop" />
-    <Reference Include="Microsoft.VisualStudio.Shell.12.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.12.0" />
-    <Reference Include="Newtonsoft.Json, Version=4.0.3.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.4.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Design" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="System.Xml" />
-    <Reference Include="TechTalk.SpecFlow">
-      <HintPath>..\packages\SpecFlow.1.9.0\lib\net35\TechTalk.SpecFlow.dll</HintPath>
-    </Reference>
-    <Reference Include="TechTalk.SpecFlow.Generator">
-      <HintPath>..\packages\SpecFlow.CustomPlugin.1.9.0\lib\net40\TechTalk.SpecFlow.Generator.dll</HintPath>
-    </Reference>
-    <Reference Include="TechTalk.SpecFlow.Parser">
-      <HintPath>..\packages\SpecFlow.CustomPlugin.1.9.0\lib\net40\TechTalk.SpecFlow.Parser.dll</HintPath>
-    </Reference>
-    <Reference Include="TechTalk.SpecFlow.Utils">
-      <HintPath>..\packages\SpecFlow.CustomPlugin.1.9.0\lib\net40\TechTalk.SpecFlow.Utils.dll</HintPath>
-    </Reference>
-    <Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="VSLangProj2, Version=7.0.5000.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="VSLangProj80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-  <ItemGroup>
-    <COMReference Include="EnvDTE">
-      <Guid>{80CC9F66-E7D8-4DDD-85B6-D9E6CD0E93E2}</Guid>
-      <VersionMajor>8</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="EnvDTE100">
-      <Guid>{26AD1324-4B7C-44BC-84F8-B86AED45729F}</Guid>
-      <VersionMajor>10</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="EnvDTE80">
-      <Guid>{1A31287A-4D7D-413E-8E32-3B374931BD89}</Guid>
-      <VersionMajor>8</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="EnvDTE90">
-      <Guid>{2CE2370E-D744-4936-A090-3FFFE667B0E1}</Guid>
-      <VersionMajor>9</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="Microsoft.VisualStudio.CommandBars">
-      <Guid>{1CBA492E-7263-47BB-87FE-639000619B15}</Guid>
-      <VersionMajor>8</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="stdole">
-      <Guid>{00020430-0000-0000-C000-000000000046}</Guid>
-      <VersionMajor>2</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="..\CommonAssemblyInfo.cs">
-      <Link>Properties\CommonAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="AutoComplete\CompletionCommandFilter.cs" />
-    <Compile Include="AutoComplete\CustomCompletionSet.cs" />
-    <Compile Include="AutoComplete\GherkinCompletionCommandFilter.cs" />
-    <Compile Include="AutoComplete\GherkinStepCompletionSource.cs" />
-    <Compile Include="AutoComplete\HierarchicalCompletionSet.cs" />
-    <Compile Include="AutoComplete\IntellisensePresenter\Text2Visibility.cs" />
-    <Compile Include="AutoComplete\IntellisensePresenter\CompletionSessionPresenter.cs" />
-    <Compile Include="AutoComplete\IntellisensePresenter\CompletionSessionView.xaml.cs">
-      <DependentUpon>CompletionSessionView.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="AutoComplete\IntellisensePresenter\IntellisensePresenterProvider.cs" />
-    <Compile Include="Commands\ContextDependentNavigationCommand.cs" />
-    <Compile Include="Commands\GenerateStepDefinitionSkeletonCommand.cs" />
-    <Compile Include="Commands\GoToStepDefinitionCommand.cs" />
-    <Compile Include="Commands\GoToStepsCommand.cs" />
-    <Compile Include="Bindings\Discovery\VsBindingRegistryBuilder.cs" />
-    <Compile Include="Commands\IEditorCommand.cs" />
-    <Compile Include="Commands\ReGenerateAllCommand.cs" />
-    <Compile Include="Commands\DebugScenariosCommand.cs" />
-    <Compile Include="Commands\DelegateMenuCommandHandler.cs" />
-    <Compile Include="Commands\RegisterCommands.cs" />
-    <Compile Include="Commands\RunScenariosCommand.cs" />
-    <Compile Include="Commands\SpecFlowProjectSingleSelectionCommand.cs" />
-    <Compile Include="EditorCommands\CommentUncommentCommand.cs" />
-    <Compile Include="EditorCommands\EditorCommandFilter.cs" />
-    <Compile Include="EditorCommands\FormatTableCommand.cs" />
-    <Compile Include="EditorCommands\GherkinEditorContext.cs" />
-    <Compile Include="EditorCommands\GherkinTextViewCreationListener.cs" />
-    <Compile Include="EditorCommands\ReSharperCommand.cs" />
-    <Compile Include="LanguageService\IdleTaskProcessingQueue.cs" />
-    <Compile Include="LanguageService\IGherkinProcessingTask.cs" />
-    <Compile Include="TestRunner\AutoTestRunnerGatewayLoader.cs" />
-    <Compile Include="TestRunner\SpecRunTestMethodResolver.cs" />
-    <Compile Include="TestRunner\SpecRunWithVsTestExplorerGatewayLoader.cs" />
-    <Compile Include="TestRunner\VsTestExplorerGateway.cs" />
-    <Compile Include="UI\ContextMenuBuilder.cs" />
-    <Compile Include="Generator\VsGeneratorInfoProvider.cs" />
-    <Compile Include="Install\VsBrowserGuidanceNotificationService.cs" />
-    <Compile Include="LanguageService\BindingFilesTracker.cs" />
-    <Compile Include="Bindings\Discovery\VsBindingMethodLocator.cs" />
-    <Compile Include="LanguageService\ProjectFeatureFilesTracker.cs" />
-    <Compile Include="LanguageService\ProjectFilesTracker.cs" />
-    <Compile Include="LanguageService\VsBindingReflectionFactory.cs" />
-    <Compile Include="LanguageService\VsStepSuggestionProvider.cs" />
-    <Compile Include="Commands\MenuCommandHandler.cs" />
-    <Compile Include="SingleFileGenerator\CodeGeneratorRegistrationWithFileExtensionAttribute.cs" />
-    <Compile Include="SingleFileGenerator\SingleFileGeneratorSupportRegistrationAttribute.cs" />
-    <Compile Include="SingleFileGenerator\SpecFlowSingleFileGenerator.cs" />
-    <Compile Include="SingleFileGenerator\SpecFlowSingleFileGeneratorBase.cs" />
-    <Compile Include="SingleFileGenerator\SingleFileGeneratorBase.cs" />
-    <Compile Include="StepSuggestions\BindingMap.cs" />
-    <Compile Include="StepSuggestions\StepMapSetializer.cs" />
-    <Compile Include="TestRunner\AutoTestRunnerGateway.cs" />
-    <Compile Include="TestRunner\CommandBasedTestRunnerGateway.cs" />
-    <Compile Include="TestRunner\ITestRunnerGateway.cs" />
-    <Compile Include="TestRunner\ITestRunnerGatewayProvider.cs" />
-    <Compile Include="TestRunner\ReSharper6TestRunnerGateway.cs" />
-    <Compile Include="TestRunner\SpecRunTestRunnerGateway.cs" />
-    <Compile Include="TestRunner\TestRunnerEngine.cs" />
-    <Compile Include="UI\GenerateStepDefinitionSkeletonForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="UI\GenerateStepDefinitionSkeletonForm.Designer.cs">
-      <DependentUpon>GenerateStepDefinitionSkeletonForm.cs</DependentUpon>
-    </Compile>
-    <Compile Include="UI\VsContextMenuManager.cs" />
-    <Compile Include="Utils\FileChangeEventsListener.cs" />
-    <Compile Include="Utils\SolutionEventsListener.cs" />
-    <Compile Include="Utils\VsProjectFilesTracker.cs" />
-    <Compile Include="Utils\VsProjectFileTrackerBase.cs" />
-    <Compile Include="Utils\VsProjectReferencesTracker.cs" />
-    <Compile Include="VsContainerBuilder.cs" />
-    <Compile Include="VsSpecFlowConfigurationReader.cs" />
-    <Compile Include="Guids.cs" />
-    <Compile Include="LanguageService\GherkinBufferServiceManager.cs" />
-    <Compile Include="LanguageService\NoProjectScope.cs" />
-    <Compile Include="LanguageService\VsProjectScope.cs" />
-    <Compile Include="Generator\VsGeneratorServices.cs" />
-    <Compile Include="StepSuggestions\BoundStepSuggestions.cs" />
-    <Compile Include="StepSuggestions\INativeSuggestionItemFactory.cs" />
-    <Compile Include="StepSuggestions\IStepSuggestion.cs" />
-    <Compile Include="StepSuggestions\StepInstance.cs" />
-    <Compile Include="StepSuggestions\StepInstanceTemplate.cs" />
-    <Compile Include="StepSuggestions\StepSuggestionList.cs" />
-    <Compile Include="StepSuggestions\StepSuggestionProvider.cs" />
-    <Compile Include="Utils\RegexDictionary.cs" />
-    <Compile Include="Utils\StringLiteralHelper.cs" />
-    <Compile Include="Utils\VsProjectFileTracker.cs" />
-    <Compile Include="Utils\DteWithEvents.cs" />
-    <Compile Include="Utils\EnumerableExtensions.cs" />
-    <Compile Include="LanguageService\GherkinFileBlockBuilder.cs" />
-    <Compile Include="LanguageService\GherkinFileScope.cs" />
-    <Compile Include="LanguageService\GherkinFileScopeChange.cs" />
-    <Compile Include="LanguageService\GherkinFileScopeExtensions.cs" />
-    <Compile Include="LanguageService\GherkinLanguageService.cs" />
-    <Compile Include="LanguageService\GherkinLanguageServiceFactory.cs" />
-    <Compile Include="LanguageService\GherkinScopeAnalyzer.cs" />
-    <Compile Include="LanguageService\GherkinTextBufferChange.cs" />
-    <Compile Include="LanguageService\GherkinTextBufferParser.cs" />
-    <Compile Include="LanguageService\GherkinTextBufferParserListener.cs" />
-    <Compile Include="LanguageService\GherkinTextBufferPartialParserListener.cs" />
-    <Compile Include="LanguageService\IGherkinFileScope.cs" />
-    <Compile Include="LanguageService\GherkinProcessingScheduler.cs" />
-    <Compile Include="LanguageService\ProjectScope.cs" />
-    <Compile Include="LanguageService\ProjectScopeFactory.cs" />
-    <Compile Include="LanguageService\ShiftedGherkinFileBlock.cs" />
-    <Compile Include="Utils\SynchronizationHelper.cs" />
-    <Compile Include="Options\OptionsPageGeneral.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="Options\IntegrationOptionsProvider.cs" />
-    <Compile Include="Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="SpecFlowPackage.cs" />
-    <Compile Include="Tracing\IVisualStudioTracer.cs" />
-    <Compile Include="Tracing\OutputWindow\IOutputWindowDefinitionMetadata.cs" />
-    <Compile Include="Tracing\OutputWindow\IOutputWindowPane.cs" />
-    <Compile Include="Tracing\OutputWindow\IOutputWindowService.cs" />
-    <Compile Include="Tracing\OutputWindow\OutputWindowDefinition.cs" />
-    <Compile Include="Tracing\OutputWindow\OutputWindowService.cs" />
-    <Compile Include="Tracing\OutputWindow\PredefinedOutputWindowPanes.cs" />
-    <Compile Include="Tracing\OutputWindow\ServiceProviderExtensions.cs" />
-    <Compile Include="Tracing\OutputWindowDefinitions.cs" />
-    <Compile Include="Tracing\OutputWindow\VsOutputWindowPaneAdapter.cs" />
-    <Compile Include="Tracing\VisualStudioTracer.cs" />
-    <Compile Include="Utils\VsxHelper.cs" />
-    <Compile Include="GherkinFileEditor\GherkinFileClassifierFormats.cs" />
-    <Compile Include="GherkinFileEditor\GherkinFileClassificationDefinition.cs" />
-    <Compile Include="GherkinFileEditor\GherkinFileClassifier.cs" />
-    <Compile Include="GherkinFileEditor\GherkinFileEditorClassifications.cs" />
-    <Compile Include="GherkinFileEditor\GherkinFileOutliningTagger.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-    <None Include="Resources\AutoCompleteIcons.psd" />
-    <None Include="source.extension.vsixmanifest">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\Resources\gherkin.ico">
-      <Link>gherkin.ico</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="..\Resources\specflowsetup.ico">
-      <Link>specflowsetup.ico</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="..\Resources\specflow_preview.png">
-      <Link>specflow_preview.png</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <VSCTCompile Include="Vs2010Integration.vsct">
-      <ResourceName>Menus.ctmenu</ResourceName>
-      <SubType>Designer</SubType>
-    </VSCTCompile>
-    <Resource Include="Resources\autocomplete-g-b.png" />
-    <Resource Include="Resources\autocomplete-g-t.png" />
-    <Resource Include="Resources\autocomplete-g.png" />
-    <Resource Include="Resources\autocomplete-t-b.png" />
-    <Resource Include="Resources\autocomplete-t-t.png" />
-    <Resource Include="Resources\autocomplete-t.png" />
-    <Resource Include="Resources\autocomplete-w-b.png" />
-    <Resource Include="Resources\autocomplete-w-t.png" />
-    <Resource Include="Resources\autocomplete-w.png" />
-    <Resource Include="Resources\autocomplete-nb.png" />
-    <Content Include="Resources\specflowpackage.ico" />
-    <Content Include="Tracing\OutputWindow\readme.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\IdeIntegration\TechTalk.SpecFlow.IdeIntegration.csproj">
-      <Project>{44D52C1B-0ABC-44B6-8EB8-0F754E264226}</Project>
-      <Name>TechTalk.SpecFlow.IdeIntegration</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\ItemTemplates\TechTalk.SpecFlow.VsIntegration.ItemTemplates.csproj">
-      <Project>{662A06B2-A852-47C4-A258-D84FE81D4A80}</Project>
-      <Name>TechTalk.SpecFlow.VsIntegration.ItemTemplates</Name>
-      <VSIXSubPath>ItemTemplates</VSIXSubPath>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <IncludeOutputGroupsInVSIX>TemplateProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Include="UI\GenerateStepDefinitionSkeletonForm.resx">
-      <DependentUpon>GenerateStepDefinitionSkeletonForm.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="VSPackage.resx">
-      <MergeWithCTO>true</MergeWithCTO>
-      <LogicalName>VSPackage.resources</LogicalName>
-      <ManifestResourceName>VSPackage</ManifestResourceName>
-      <LastGenOutput>VSPackage.Designer.cs</LastGenOutput>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-  </ItemGroup>
-  <PropertyGroup>
-    <UseCodebase>true</UseCodebase>
-    <MSBuildCommunityTasksPath>$(SolutionDir)\.build</MSBuildCommunityTasksPath>
-  </PropertyGroup>
-  <ItemGroup>
-    <Page Include="AutoComplete\IntellisensePresenter\CompletionSessionView.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
-  <Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets" />
-  <Target Name="AfterBuild">
-    <RemoveDir Directories="$(TargetDir)\VSIX" />
-    <Unzip ZipFileName="$(TargetDir)\TechTalk.SpecFlow.VsIntegration.vsix" TargetDirectory="$(TargetDir)\VSIX" />
-    <Delete Files="$(TargetDir)\TechTalk.SpecFlow.VsIntegration.vsix.orig" />
-    <Move SourceFiles="$(TargetDir)\TechTalk.SpecFlow.VsIntegration.vsix" DestinationFiles="$(TargetDir)\TechTalk.SpecFlow.VsIntegration.vsix.orig" />
-    <ItemGroup>
-      <VsFiles Include="$(TargetDir)\VSIX\EnvDTE*.dll" />
-      <VsFiles Include="$(TargetDir)\VSIX\VSLangProj*.dll" />
-      <VsFiles Include="$(TargetDir)\VSIX\Microsoft.VisualStudio.*.dll" />
-    </ItemGroup>
-    <Delete Files="@(VsFiles)" />
-    <ItemGroup>
-      <VsixFiles Include="$(TargetDir)\VSIX\**\*.*" />
-    </ItemGroup>
-    <Zip Files="@(VsixFiles)" Flatten="false" WorkingDirectory="$(TargetDir)\VSIX" ZipFileName="$(TargetDir)\TechTalk.SpecFlow.VsIntegration.vsix" />
-  </Target>
+	<PropertyGroup>    
+		<VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+		<VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+		<VSCommonExtensionsPath Condition="'$(VSCommonExtensionsPath)' == ''">$(MSBuildExtensionsPath32)\..\Microsoft Visual Studio $(VisualStudioVersion)\Common7\IDE\CommonExtensions</VSCommonExtensionsPath>
+	</PropertyGroup>
+
+	<!-- This is the property that causes VS 2012+ to insist on one-way update of the project -->
+	<PropertyGroup Condition="'$(VisualStudioVersion)' &gt;= '11.0'">
+		<MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
+	</PropertyGroup>
+	<!-- This is an additional property added by VS 2013 -->
+	<PropertyGroup Condition="'$(VisualStudioVersion)' &gt;= '12.0'">
+		<OldToolsVersion>4.0</OldToolsVersion>
+	</PropertyGroup>
+	<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<ProductVersion>10.0.20305</ProductVersion>
+		<SchemaVersion>2.0</SchemaVersion>
+		<ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+		<ProjectGuid>{96294E6F-8875-4D12-8577-4EC83E60BD6C}</ProjectGuid>
+		<OutputType>Library</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<RootNamespace>TechTalk.SpecFlow.VsIntegration</RootNamespace>
+		<AssemblyName>TechTalk.SpecFlow.VsIntegration</AssemblyName>
+		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+		<SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DebugSymbols>true</DebugSymbols>
+		<DebugType>full</DebugType>
+		<Optimize>false</Optimize>
+		<OutputPath>bin\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+		<DeployExtension>True</DeployExtension>
+		<Prefer32Bit>false</Prefer32Bit>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DebugType>pdbonly</DebugType>
+		<Optimize>true</Optimize>
+		<OutputPath>bin\Release\</OutputPath>
+		<DefineConstants>TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+		<DeployExtension>False</DeployExtension>
+		<Prefer32Bit>false</Prefer32Bit>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(VSSDK)' == ''">
+		<VSSDKVar>VSSDK$(VisualStudioVersion.Replace('.', ''))Install</VSSDKVar>
+		<VSSDK>$([System.Environment]::ExpandEnvironmentVariables('%$(VSSDKVar)%'))VisualStudioIntegration\Common\Assemblies\</VSSDK>
+	</PropertyGroup>
+	<PropertyGroup>
+		<VSSDK20>$(VSSDK)v2.0\</VSSDK20>
+		<VSSDK40>$(VSSDK)v4.0\</VSSDK40>
+		<VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+	</PropertyGroup>
+	<!-- On build servers and command line, this property is not available, so we redefine it in
+         terms of the environment variables created by VS when installed -->
+	<PropertyGroup Condition="'$(DevEnvDir)' == ''">
+		<VSCommToolsVar>VS$(VisualStudioVersion.Replace('.', ''))COMNTOOLS</VSCommToolsVar>
+		<DevEnvDir>$([System.Environment]::ExpandEnvironmentVariables('%$(VSCommToolsVar)%'))..\IDE\</DevEnvDir>
+	</PropertyGroup>
+	<PropertyGroup>
+		<PublicAssemblies>$(DevEnvDir)PublicAssemblies\</PublicAssemblies>
+		<PrivateAssemblies>$(DevEnvDir)PublicAssemblies\</PrivateAssemblies>
+	</PropertyGroup>
+	<ItemGroup>
+		<Reference Include="Microsoft.CSharp" />
+		<Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+		<Reference Include="Microsoft.VisualStudio.CoreUtility, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+		<Reference Include="Microsoft.VisualStudio.Designer.Interfaces, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+			<EmbedInteropTypes>True</EmbedInteropTypes>
+		</Reference>
+		<Reference Include="Microsoft.VisualStudio.Editor, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+		<Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+		<Reference Include="Microsoft.VisualStudio.OLE.Interop" />
+		<Reference Include="Microsoft.VisualStudio.Shell.Interop" />
+		<Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0" />
+		<Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
+		<Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
+		<Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0">
+			<EmbedInteropTypes>False</EmbedInteropTypes>
+		</Reference>
+		<Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0"  >
+			<EmbedInteropTypes>False</EmbedInteropTypes>
+		</Reference>
+
+
+		<Reference Include="Microsoft.VisualStudio.TestWindow">
+			<HintPath>$(VSCommonExtensionsPath)\Microsoft\TestWindow\Microsoft.VisualStudio.TestWindow.dll</HintPath>
+		</Reference>
+		<Reference Include="Microsoft.VisualStudio.TestWindow.Core">
+			<HintPath>$(VSCommonExtensionsPath)\Microsoft\TestWindow\Microsoft.VisualStudio.TestWindow.Core.dll</HintPath>
+		</Reference>
+		<Reference Include="Microsoft.VisualStudio.TestWindow.Interfaces">
+			<HintPath>$(VSCommonExtensionsPath)\Microsoft\TestWindow\Microsoft.VisualStudio.TestWindow.Interfaces.dll</HintPath>
+			<EmbedInteropTypes>False</EmbedInteropTypes>
+		</Reference>		
+		<Reference Include="Microsoft.VisualStudio.Text.Data, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+		<Reference Include="Microsoft.VisualStudio.Text.Logic, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+		<Reference Include="Microsoft.VisualStudio.Text.UI, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+		<Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+		<Reference Include="Microsoft.VisualStudio.TextManager.Interop" />
+		<Reference Include="Microsoft.VisualStudio.Shell.$(VisualStudioVersion)" />
+		<Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" />
+		<Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" />
+		<Reference Include="Microsoft.VisualStudio.Shell.Immutable.12.0" />
+
+
+		<Reference Include="Newtonsoft.Json, Version=4.0.3.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+			<SpecificVersion>False</SpecificVersion>
+			<HintPath>..\packages\Newtonsoft.Json.4.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
+		</Reference>
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="System" />
+		<Reference Include="System.ComponentModel.Composition" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data" />
+		<Reference Include="System.Design" />
+		<Reference Include="System.Drawing" />
+		<Reference Include="System.Web" />
+		<Reference Include="System.Windows.Forms" />
+		<Reference Include="System.Xaml" />
+		<Reference Include="System.Xml" />
+		<Reference Include="TechTalk.SpecFlow">
+			<HintPath>..\packages\SpecFlow.1.9.0\lib\net35\TechTalk.SpecFlow.dll</HintPath>
+		</Reference>
+		<Reference Include="TechTalk.SpecFlow.Generator">
+			<HintPath>..\packages\SpecFlow.CustomPlugin.1.9.0\lib\net40\TechTalk.SpecFlow.Generator.dll</HintPath>
+		</Reference>
+		<Reference Include="TechTalk.SpecFlow.Parser">
+			<HintPath>..\packages\SpecFlow.CustomPlugin.1.9.0\lib\net40\TechTalk.SpecFlow.Parser.dll</HintPath>
+		</Reference>
+		<Reference Include="TechTalk.SpecFlow.Utils">
+			<HintPath>..\packages\SpecFlow.CustomPlugin.1.9.0\lib\net40\TechTalk.SpecFlow.Utils.dll</HintPath>
+		</Reference>
+		<Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+			<EmbedInteropTypes>False</EmbedInteropTypes>
+		</Reference>
+		<Reference Include="VSLangProj2, Version=7.0.5000.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+			<EmbedInteropTypes>False</EmbedInteropTypes>
+		</Reference>
+		<Reference Include="VSLangProj80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+			<EmbedInteropTypes>False</EmbedInteropTypes>
+		</Reference>
+		<Reference Include="WindowsBase" />
+	</ItemGroup>
+	<ItemGroup>
+		<COMReference Include="EnvDTE">
+			<Guid>{80CC9F66-E7D8-4DDD-85B6-D9E6CD0E93E2}</Guid>
+			<VersionMajor>8</VersionMajor>
+			<VersionMinor>0</VersionMinor>
+			<Lcid>0</Lcid>
+			<WrapperTool>primary</WrapperTool>
+			<Isolated>False</Isolated>
+			<EmbedInteropTypes>False</EmbedInteropTypes>
+		</COMReference>
+		<COMReference Include="EnvDTE100">
+			<Guid>{26AD1324-4B7C-44BC-84F8-B86AED45729F}</Guid>
+			<VersionMajor>10</VersionMajor>
+			<VersionMinor>0</VersionMinor>
+			<Lcid>0</Lcid>
+			<WrapperTool>primary</WrapperTool>
+			<Isolated>False</Isolated>
+			<EmbedInteropTypes>False</EmbedInteropTypes>
+		</COMReference>
+		<COMReference Include="EnvDTE80">
+			<Guid>{1A31287A-4D7D-413E-8E32-3B374931BD89}</Guid>
+			<VersionMajor>8</VersionMajor>
+			<VersionMinor>0</VersionMinor>
+			<Lcid>0</Lcid>
+			<WrapperTool>primary</WrapperTool>
+			<Isolated>False</Isolated>
+			<EmbedInteropTypes>False</EmbedInteropTypes>
+		</COMReference>
+		<COMReference Include="EnvDTE90">
+			<Guid>{2CE2370E-D744-4936-A090-3FFFE667B0E1}</Guid>
+			<VersionMajor>9</VersionMajor>
+			<VersionMinor>0</VersionMinor>
+			<Lcid>0</Lcid>
+			<WrapperTool>primary</WrapperTool>
+			<Isolated>False</Isolated>
+			<EmbedInteropTypes>False</EmbedInteropTypes>
+		</COMReference>
+		<COMReference Include="Microsoft.VisualStudio.CommandBars">
+			<Guid>{1CBA492E-7263-47BB-87FE-639000619B15}</Guid>
+			<VersionMajor>8</VersionMajor>
+			<VersionMinor>0</VersionMinor>
+			<Lcid>0</Lcid>
+			<WrapperTool>primary</WrapperTool>
+			<Isolated>False</Isolated>
+			<EmbedInteropTypes>False</EmbedInteropTypes>
+		</COMReference>
+		<COMReference Include="stdole">
+			<Guid>{00020430-0000-0000-C000-000000000046}</Guid>
+			<VersionMajor>2</VersionMajor>
+			<VersionMinor>0</VersionMinor>
+			<Lcid>0</Lcid>
+			<WrapperTool>primary</WrapperTool>
+			<Isolated>False</Isolated>
+			<EmbedInteropTypes>False</EmbedInteropTypes>
+		</COMReference>
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Include="..\CommonAssemblyInfo.cs">
+			<Link>Properties\CommonAssemblyInfo.cs</Link>
+		</Compile>
+		<Compile Include="AutoComplete\CompletionCommandFilter.cs" />
+		<Compile Include="AutoComplete\CustomCompletionSet.cs" />
+		<Compile Include="AutoComplete\GherkinCompletionCommandFilter.cs" />
+		<Compile Include="AutoComplete\GherkinStepCompletionSource.cs" />
+		<Compile Include="AutoComplete\HierarchicalCompletionSet.cs" />
+		<Compile Include="AutoComplete\IntellisensePresenter\Text2Visibility.cs" />
+		<Compile Include="AutoComplete\IntellisensePresenter\CompletionSessionPresenter.cs" />
+		<Compile Include="AutoComplete\IntellisensePresenter\CompletionSessionView.xaml.cs">
+			<DependentUpon>CompletionSessionView.xaml</DependentUpon>
+		</Compile>
+		<Compile Include="AutoComplete\IntellisensePresenter\IntellisensePresenterProvider.cs" />
+		<Compile Include="Commands\ContextDependentNavigationCommand.cs" />
+		<Compile Include="Commands\GenerateStepDefinitionSkeletonCommand.cs" />
+		<Compile Include="Commands\GoToStepDefinitionCommand.cs" />
+		<Compile Include="Commands\GoToStepsCommand.cs" />
+		<Compile Include="Bindings\Discovery\VsBindingRegistryBuilder.cs" />
+		<Compile Include="Commands\IEditorCommand.cs" />
+		<Compile Include="Commands\ReGenerateAllCommand.cs" />
+		<Compile Include="Commands\DebugScenariosCommand.cs" />
+		<Compile Include="Commands\DelegateMenuCommandHandler.cs" />
+		<Compile Include="Commands\RegisterCommands.cs" />
+		<Compile Include="Commands\RunScenariosCommand.cs" />
+		<Compile Include="Commands\SpecFlowProjectSingleSelectionCommand.cs" />
+		<Compile Include="EditorCommands\CommentUncommentCommand.cs" />
+		<Compile Include="EditorCommands\EditorCommandFilter.cs" />
+		<Compile Include="EditorCommands\FormatTableCommand.cs" />
+		<Compile Include="EditorCommands\GherkinEditorContext.cs" />
+		<Compile Include="EditorCommands\GherkinTextViewCreationListener.cs" />
+		<Compile Include="EditorCommands\ReSharperCommand.cs" />
+		<Compile Include="LanguageService\IdleTaskProcessingQueue.cs" />
+		<Compile Include="LanguageService\IGherkinProcessingTask.cs" />
+		<Compile Include="TestRunner\AutoTestRunnerGatewayLoader.cs" />
+		<Compile Include="TestRunner\SpecRunTestMethodResolver.cs" />
+		<Compile Include="TestRunner\SpecRunWithVsTestExplorerGatewayLoader.cs" />
+		<Compile Include="TestRunner\VsTestExplorerGateway.cs" />
+		<Compile Include="UI\ContextMenuBuilder.cs" />
+		<Compile Include="Generator\VsGeneratorInfoProvider.cs" />
+		<Compile Include="Install\VsBrowserGuidanceNotificationService.cs" />
+		<Compile Include="LanguageService\BindingFilesTracker.cs" />
+		<Compile Include="Bindings\Discovery\VsBindingMethodLocator.cs" />
+		<Compile Include="LanguageService\ProjectFeatureFilesTracker.cs" />
+		<Compile Include="LanguageService\ProjectFilesTracker.cs" />
+		<Compile Include="LanguageService\VsBindingReflectionFactory.cs" />
+		<Compile Include="LanguageService\VsStepSuggestionProvider.cs" />
+		<Compile Include="Commands\MenuCommandHandler.cs" />
+		<Compile Include="SingleFileGenerator\CodeGeneratorRegistrationWithFileExtensionAttribute.cs" />
+		<Compile Include="SingleFileGenerator\SingleFileGeneratorSupportRegistrationAttribute.cs" />
+		<Compile Include="SingleFileGenerator\SpecFlowSingleFileGenerator.cs" />
+		<Compile Include="SingleFileGenerator\SpecFlowSingleFileGeneratorBase.cs" />
+		<Compile Include="SingleFileGenerator\SingleFileGeneratorBase.cs" />
+		<Compile Include="StepSuggestions\BindingMap.cs" />
+		<Compile Include="StepSuggestions\StepMapSetializer.cs" />
+		<Compile Include="TestRunner\AutoTestRunnerGateway.cs" />
+		<Compile Include="TestRunner\CommandBasedTestRunnerGateway.cs" />
+		<Compile Include="TestRunner\ITestRunnerGateway.cs" />
+		<Compile Include="TestRunner\ITestRunnerGatewayProvider.cs" />
+		<Compile Include="TestRunner\ReSharper6TestRunnerGateway.cs" />
+		<Compile Include="TestRunner\SpecRunTestRunnerGateway.cs" />
+		<Compile Include="TestRunner\TestRunnerEngine.cs" />
+		<Compile Include="UI\GenerateStepDefinitionSkeletonForm.cs">
+			<SubType>Form</SubType>
+		</Compile>
+		<Compile Include="UI\GenerateStepDefinitionSkeletonForm.Designer.cs">
+			<DependentUpon>GenerateStepDefinitionSkeletonForm.cs</DependentUpon>
+		</Compile>
+		<Compile Include="UI\VsContextMenuManager.cs" />
+		<Compile Include="Utils\FileChangeEventsListener.cs" />
+		<Compile Include="Utils\SolutionEventsListener.cs" />
+		<Compile Include="Utils\VsProjectFilesTracker.cs" />
+		<Compile Include="Utils\VsProjectFileTrackerBase.cs" />
+		<Compile Include="Utils\VsProjectReferencesTracker.cs" />
+		<Compile Include="VsContainerBuilder.cs" />
+		<Compile Include="VsSpecFlowConfigurationReader.cs" />
+		<Compile Include="Guids.cs" />
+		<Compile Include="LanguageService\GherkinBufferServiceManager.cs" />
+		<Compile Include="LanguageService\NoProjectScope.cs" />
+		<Compile Include="LanguageService\VsProjectScope.cs" />
+		<Compile Include="Generator\VsGeneratorServices.cs" />
+		<Compile Include="StepSuggestions\BoundStepSuggestions.cs" />
+		<Compile Include="StepSuggestions\INativeSuggestionItemFactory.cs" />
+		<Compile Include="StepSuggestions\IStepSuggestion.cs" />
+		<Compile Include="StepSuggestions\StepInstance.cs" />
+		<Compile Include="StepSuggestions\StepInstanceTemplate.cs" />
+		<Compile Include="StepSuggestions\StepSuggestionList.cs" />
+		<Compile Include="StepSuggestions\StepSuggestionProvider.cs" />
+		<Compile Include="Utils\RegexDictionary.cs" />
+		<Compile Include="Utils\StringLiteralHelper.cs" />
+		<Compile Include="Utils\VsProjectFileTracker.cs" />
+		<Compile Include="Utils\DteWithEvents.cs" />
+		<Compile Include="Utils\EnumerableExtensions.cs" />
+		<Compile Include="LanguageService\GherkinFileBlockBuilder.cs" />
+		<Compile Include="LanguageService\GherkinFileScope.cs" />
+		<Compile Include="LanguageService\GherkinFileScopeChange.cs" />
+		<Compile Include="LanguageService\GherkinFileScopeExtensions.cs" />
+		<Compile Include="LanguageService\GherkinLanguageService.cs" />
+		<Compile Include="LanguageService\GherkinLanguageServiceFactory.cs" />
+		<Compile Include="LanguageService\GherkinScopeAnalyzer.cs" />
+		<Compile Include="LanguageService\GherkinTextBufferChange.cs" />
+		<Compile Include="LanguageService\GherkinTextBufferParser.cs" />
+		<Compile Include="LanguageService\GherkinTextBufferParserListener.cs" />
+		<Compile Include="LanguageService\GherkinTextBufferPartialParserListener.cs" />
+		<Compile Include="LanguageService\IGherkinFileScope.cs" />
+		<Compile Include="LanguageService\GherkinProcessingScheduler.cs" />
+		<Compile Include="LanguageService\ProjectScope.cs" />
+		<Compile Include="LanguageService\ProjectScopeFactory.cs" />
+		<Compile Include="LanguageService\ShiftedGherkinFileBlock.cs" />
+		<Compile Include="Utils\SynchronizationHelper.cs" />
+		<Compile Include="Options\OptionsPageGeneral.cs">
+			<SubType>Component</SubType>
+		</Compile>
+		<Compile Include="Options\IntegrationOptionsProvider.cs" />
+		<Compile Include="Resources.Designer.cs">
+			<AutoGen>True</AutoGen>
+			<DesignTime>True</DesignTime>
+			<DependentUpon>Resources.resx</DependentUpon>
+		</Compile>
+		<Compile Include="SpecFlowPackage.cs" />
+		<Compile Include="Tracing\IVisualStudioTracer.cs" />
+		<Compile Include="Tracing\OutputWindow\IOutputWindowDefinitionMetadata.cs" />
+		<Compile Include="Tracing\OutputWindow\IOutputWindowPane.cs" />
+		<Compile Include="Tracing\OutputWindow\IOutputWindowService.cs" />
+		<Compile Include="Tracing\OutputWindow\OutputWindowDefinition.cs" />
+		<Compile Include="Tracing\OutputWindow\OutputWindowService.cs" />
+		<Compile Include="Tracing\OutputWindow\PredefinedOutputWindowPanes.cs" />
+		<Compile Include="Tracing\OutputWindow\ServiceProviderExtensions.cs" />
+		<Compile Include="Tracing\OutputWindowDefinitions.cs" />
+		<Compile Include="Tracing\OutputWindow\VsOutputWindowPaneAdapter.cs" />
+		<Compile Include="Tracing\VisualStudioTracer.cs" />
+		<Compile Include="Utils\VsxHelper.cs" />
+		<Compile Include="GherkinFileEditor\GherkinFileClassifierFormats.cs" />
+		<Compile Include="GherkinFileEditor\GherkinFileClassificationDefinition.cs" />
+		<Compile Include="GherkinFileEditor\GherkinFileClassifier.cs" />
+		<Compile Include="GherkinFileEditor\GherkinFileEditorClassifications.cs" />
+		<Compile Include="GherkinFileEditor\GherkinFileOutliningTagger.cs" />
+		<Compile Include="Properties\AssemblyInfo.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="packages.config" />
+		<None Include="Resources\AutoCompleteIcons.psd" />
+		<None Include="source.extension.vsixmanifest">
+			<SubType>Designer</SubType>
+		</None>
+	</ItemGroup>
+	<ItemGroup>
+		<Content Include="..\Resources\gherkin.ico">
+			<Link>gherkin.ico</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<IncludeInVSIX>true</IncludeInVSIX>
+		</Content>
+		<Content Include="..\Resources\specflowsetup.ico">
+			<Link>specflowsetup.ico</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<IncludeInVSIX>true</IncludeInVSIX>
+		</Content>
+		<Content Include="..\Resources\specflow_preview.png">
+			<Link>specflow_preview.png</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<IncludeInVSIX>true</IncludeInVSIX>
+		</Content>
+		<VSCTCompile Include="Vs2010Integration.vsct">
+			<ResourceName>Menus.ctmenu</ResourceName>
+			<SubType>Designer</SubType>
+		</VSCTCompile>
+		<Resource Include="Resources\autocomplete-g-b.png" />
+		<Resource Include="Resources\autocomplete-g-t.png" />
+		<Resource Include="Resources\autocomplete-g.png" />
+		<Resource Include="Resources\autocomplete-t-b.png" />
+		<Resource Include="Resources\autocomplete-t-t.png" />
+		<Resource Include="Resources\autocomplete-t.png" />
+		<Resource Include="Resources\autocomplete-w-b.png" />
+		<Resource Include="Resources\autocomplete-w-t.png" />
+		<Resource Include="Resources\autocomplete-w.png" />
+		<Resource Include="Resources\autocomplete-nb.png" />
+		<Content Include="..\LICENSE.txt">
+			<IncludeInVSIX>true</IncludeInVSIX>
+		</Content>
+		<Content Include="Resources\specflowpackage.ico" />
+		<Content Include="Tracing\OutputWindow\readme.txt" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\IdeIntegration\TechTalk.SpecFlow.IdeIntegration.csproj">
+			<Project>{44D52C1B-0ABC-44B6-8EB8-0F754E264226}</Project>
+			<Name>TechTalk.SpecFlow.IdeIntegration</Name>
+		</ProjectReference>
+		<ProjectReference Include="..\ItemTemplates\TechTalk.SpecFlow.VsIntegration.ItemTemplates.csproj">
+			<Project>{662A06B2-A852-47C4-A258-D84FE81D4A80}</Project>
+			<Name>TechTalk.SpecFlow.VsIntegration.ItemTemplates</Name>
+			<VSIXSubPath>ItemTemplates</VSIXSubPath>
+			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+			<IncludeOutputGroupsInVSIX>TemplateProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+		</ProjectReference>
+	</ItemGroup>
+	<ItemGroup>
+		<EmbeddedResource Include="Resources.resx">
+			<Generator>ResXFileCodeGenerator</Generator>
+			<LastGenOutput>Resources.Designer.cs</LastGenOutput>
+		</EmbeddedResource>
+		<EmbeddedResource Include="UI\GenerateStepDefinitionSkeletonForm.resx">
+			<DependentUpon>GenerateStepDefinitionSkeletonForm.cs</DependentUpon>
+		</EmbeddedResource>
+		<EmbeddedResource Include="VSPackage.resx">
+			<MergeWithCTO>true</MergeWithCTO>
+			<LogicalName>VSPackage.resources</LogicalName>
+			<ManifestResourceName>VSPackage</ManifestResourceName>
+			<LastGenOutput>VSPackage.Designer.cs</LastGenOutput>
+			<SubType>Designer</SubType>
+		</EmbeddedResource>
+	</ItemGroup> 
+	<PropertyGroup>
+		<UseCodebase>true</UseCodebase>
+		<MSBuildCommunityTasksPath>$(SolutionDir)\.build</MSBuildCommunityTasksPath>
+	</PropertyGroup>
+	<ItemGroup>
+		<Page Include="AutoComplete\IntellisensePresenter\CompletionSessionView.xaml">
+			<Generator>MSBuild:Compile</Generator>
+			<SubType>Designer</SubType>
+			<Generator>MSBuild:Compile</Generator>
+			<SubType>Designer</SubType>
+		</Page>
+	</ItemGroup>
+	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+	<Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
+	<Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets" />
+	<Target Name="AfterBuild">
+		<RemoveDir Directories="$(TargetDir)\VSIX" />
+		<Unzip ZipFileName="$(TargetDir)\TechTalk.SpecFlow.VsIntegration.vsix" TargetDirectory="$(TargetDir)\VSIX" />
+		<Delete Files="$(TargetDir)\TechTalk.SpecFlow.VsIntegration.vsix.orig" />
+		<Move SourceFiles="$(TargetDir)\TechTalk.SpecFlow.VsIntegration.vsix" DestinationFiles="$(TargetDir)\TechTalk.SpecFlow.VsIntegration.vsix.orig" />
+		<ItemGroup>
+			<VsFiles Include="$(TargetDir)\VSIX\EnvDTE*.dll" />
+			<VsFiles Include="$(TargetDir)\VSIX\VSLangProj*.dll" />
+			<VsFiles Include="$(TargetDir)\VSIX\Microsoft.VisualStudio.*.dll" />
+		</ItemGroup>
+		<Delete Files="@(VsFiles)" />
+		<ItemGroup>
+			<VsixFiles Include="$(TargetDir)\VSIX\**\*.*" />
+		</ItemGroup>
+		<Zip Files="@(VsixFiles)" Flatten="false" WorkingDirectory="$(TargetDir)\VSIX" ZipFileName="$(TargetDir)\TechTalk.SpecFlow.VsIntegration.vsix" />
+	</Target>
 </Project>

--- a/VsIntegration/source.extension.vsixmanifest
+++ b/VsIntegration/source.extension.vsixmanifest
@@ -16,6 +16,9 @@
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="12.0" />
     <InstallationTarget Id="Microsoft.VisualStudio.Premium" Version="12.0" />
     <InstallationTarget Id="Microsoft.VisualStudio.Ultimate" Version="12.0" />
+	<InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="11.0" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Premium" Version="11.0" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Ultimate" Version="11.0" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />


### PR DESCRIPTION
I found that when I had a base class without a Binding attribute and a subclass with a binding attribute, the IDE did not find the bindings in the base class. The specflow engine works fine with this configuration - it is simply the ide that has issues.  Adding a binding attribute to the base class results in duplicate bindings by the engine as well as duplicate instantiations which is problematic when using the dependency injection mode.  

This code fixes this by chaining into the base classes when looking for bindings.  I have not implemented change tracking on the base class, so you have to dirty the class with the binding attribute to get updates.

I had some struggles getting this working targetting VS 2012.  I updated the csproj to be compatible with VS 2012 and VS 2013 per the following:

http://blogs.clariusconsulting.net/kzu/how-to-create-a-visual-studio-extensibility-project-that-is-compatible-with-vs-2010-2012-and-2013/