### PR TITLE
Updated Resharper Gateway/loader to support multiple versions of Resharper 

### DIFF
--- a/VsIntegration/TestRunner/ReSharper6TestRunnerGateway.cs
+++ b/VsIntegration/TestRunner/ReSharper6TestRunnerGateway.cs
@@ -8,30 +8,55 @@ namespace TechTalk.SpecFlow.VsIntegration.TestRunner
 {
     public class ReSharper6GatewayLoader : AutoTestRunnerGatewayLoader
     {
-        public ReSharper6GatewayLoader() : base (TestRunnerTool.ReSharper)
+        public ReSharper6GatewayLoader()
+            : base(TestRunnerTool.ReSharper)
         {
         }
 
         public override bool CanUse(Project project)
         {
+            return GetResharperVersion() != -1;
+        }
+
+        public static int GetResharperVersion()
+        {
             var reSharperAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == "JetBrains.ReSharper.UnitTestFramework");
-            return reSharperAssembly != null && reSharperAssembly.GetName().Version.Major <= 5;
+            return reSharperAssembly != null ? reSharperAssembly.GetName().Version.Major : -1;
         }
     }
 
     public class ReSharper6TestRunnerGateway : CommandBasedTestRunnerGateway
     {
+        private readonly int _currentVersion;
+
         protected override string GetRunInCurrentContextCommand(bool debug)
         {
-            if (debug)
-                return "ReSharper.Reharper_ReSharperUnitTestDebugContext";
+            string commandFormat;
+            if (_currentVersion < 6)
+            {
+                commandFormat = "ReSharper.ReSharper_UnitTest_Context{0}";
+            }
+            else if (_currentVersion < 9)
+            {
+                commandFormat = "ReSharper.ReSharper_ReSharper_UnitTest_{0}Context";
+            }
+            else
+            {
+                commandFormat = "ReSharper.ReSharper_ReSharperUnitTest{0}Context";
+            }
 
-            return "ReSharper.Reharper_ReSharperUnitTestRunContext";
+            if (debug)
+            {
+                return string.Format(commandFormat, "Debug");
+            }
+            return string.Format(commandFormat, "Run");
+
         }
 
         public ReSharper6TestRunnerGateway(DTE dte, IIdeTracer tracer)
             : base(dte, tracer)
         {
+            _currentVersion = ReSharper6GatewayLoader.GetResharperVersion();
         }
     }
 }

--- a/VsIntegration/TestRunner/ReSharper6TestRunnerGateway.cs
+++ b/VsIntegration/TestRunner/ReSharper6TestRunnerGateway.cs
@@ -42,7 +42,7 @@ namespace TechTalk.SpecFlow.VsIntegration.TestRunner
             }
             else
             {
-                commandFormat = "ReSharper.ReSharper_ReSharperUnitTest{0}Context";
+                commandFormat = "ReSharper.ReSharper_UnitTest{0}Context";
             }
 
             if (debug)


### PR DESCRIPTION
Assuming that the only difference is the Run/Debug Context commands. Uses existing code to figure out what Resharper version is installed.

So far tested on VS2013 and Resharper 8.2, busy upgrading to 9 to double check.