### PR TITLE
Ensured that when a step in a scenario outline block goes through the example substitution that any table or multiline text arguments are also used on the substituted step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ test-results
 Tests/TechTalk.SpecFlow.Specs.Silverlight4.Web/ClientBin/*
 *.stackdump
 packages/*
+*.ncrunchproject
+SpecFlow.VisualStudio.v2.ncrunchsolution

--- a/VsIntegration/LanguageService/GherkinFileScopeExtensions.cs
+++ b/VsIntegration/LanguageService/GherkinFileScopeExtensions.cs
@@ -193,7 +193,10 @@ namespace TechTalk.SpecFlow.VsIntegration.LanguageService
                                                        string value;
                                                        return exampleDictionary.TryGetValue(match.Groups["param"].Value, out value) ? value : match.Value;
                                                    });
-            return new GherkinStep(step.StepDefinitionType, step.StepDefinitionKeyword, replacedText, step.StepContext, step.Keyword, step.BlockRelativeLine);
+            var substitutedStep = new GherkinStep(step.StepDefinitionType, step.StepDefinitionKeyword, replacedText, step.StepContext, step.Keyword, step.BlockRelativeLine);
+            substitutedStep.MultilineTextArgument = step.MultilineTextArgument;
+            substitutedStep.TableArgument = step.TableArgument;
+            return substitutedStep;
         }
 
         public static ScenarioOutlineExamplesRow GetExamplesRowFromPosition(this IScenarioOutlineBlock scenatioOutline, int line)

--- a/VsIntegration/LanguageService/GherkinFileScopeExtensions.cs
+++ b/VsIntegration/LanguageService/GherkinFileScopeExtensions.cs
@@ -184,19 +184,39 @@ namespace TechTalk.SpecFlow.VsIntegration.LanguageService
             return GetSubstitutedStep(step, firstNonEmptyExampleSet.ExamplesTable.Rows.First());
         }
 
-        static private readonly Regex paramRe = new Regex(@"\<(?<param>[^\>]+)\>");
+        private static readonly Regex paramRe = new Regex(@"\<(?<param>[^\>]+)\>");
         private static GherkinStep GetSubstitutedStep(GherkinStep step, IDictionary<string, string> exampleDictionary)
         {
-            var replacedText = paramRe.Replace(step.Text,
-                                               match =>
-                                                   {
-                                                       string value;
-                                                       return exampleDictionary.TryGetValue(match.Groups["param"].Value, out value) ? value : match.Value;
-                                                   });
+            var replacedText = ReplaceExamplesInText(step.Text, exampleDictionary);
             var substitutedStep = new GherkinStep(step.StepDefinitionType, step.StepDefinitionKeyword, replacedText, step.StepContext, step.Keyword, step.BlockRelativeLine);
-            substitutedStep.MultilineTextArgument = step.MultilineTextArgument;
-            substitutedStep.TableArgument = step.TableArgument;
+            substitutedStep.MultilineTextArgument = step.MultilineTextArgument==null ? null: ReplaceExamplesInText(step.MultilineTextArgument,exampleDictionary);
+            substitutedStep.TableArgument = CreateSubstitutedTable(step.TableArgument, exampleDictionary);
             return substitutedStep;
+        }
+
+        private static Table CreateSubstitutedTable(Table tableArgument,IDictionary<string, string> exampleDictionary)
+        {
+            if (tableArgument == null)
+            {
+                return null;
+            }
+            Table substitutedTable = new Table(tableArgument.Header.ToArray());
+            foreach (var row in tableArgument.Rows)
+            {
+                substitutedTable.AddRow(row.Values.Select(cell=>ReplaceExamplesInText(cell,exampleDictionary)).ToArray());
+            }
+
+            return substitutedTable;
+        }
+
+        private static string ReplaceExamplesInText(string text, IDictionary<string, string> exampleDictionary)
+        {
+            return paramRe.Replace(text,
+                match =>
+                {
+                    string value;
+                    return exampleDictionary.TryGetValue(match.Groups["param"].Value, out value) ? value : match.Value;
+                });
         }
 
         public static ScenarioOutlineExamplesRow GetExamplesRowFromPosition(this IScenarioOutlineBlock scenatioOutline, int line)


### PR DESCRIPTION
This pull request fixes the issue https://github.com/techtalk/SpecFlow/issues/487.

When steps are generated in a scenario block in a scenario outline, they have example values replaced in them. these steps are copies of the original step, but the Table and MultiLineText properties are not set, so any arguments are not generated in the resulting StepDefinition.

There are no existing tests in any of this area, so I didn't test this other than by running it in the IDE and checking that it correctly generated the step definition. I think the fix is simple enough. 