### PR TITLE
COMException when navigating to step definition

### DIFF
--- a/VsIntegration/Utils/VsxHelper.cs
+++ b/VsIntegration/Utils/VsxHelper.cs
@@ -408,7 +408,21 @@ namespace TechTalk.SpecFlow.VsIntegration.Utils
 
         public static IEnumerable<CodeClass> GetClasses(Project project)
         {
-            return GetAllProjectItem(project).Where(pi => pi.FileCodeModel != null).SelectMany(projectItem => GetClasses(projectItem.FileCodeModel.CodeElements));
+            return GetAllProjectItem(project)
+                .Where(HasFileCodeModel)
+                .SelectMany(projectItem => GetClasses(projectItem.FileCodeModel.CodeElements));
+        }
+
+        public static bool HasFileCodeModel(ProjectItem projectItem)
+        {
+            try
+            {
+                return projectItem.FileCodeModel != null;
+            }
+            catch (COMException)
+            {
+                return false;
+            }
         }
 
         public static IEnumerable<CodeClass> GetClasses(ProjectItem projectItem)


### PR DESCRIPTION
Please see: https://github.com/techtalk/SpecFlow/issues/726

This isn't the most ideal solution, but it does work as a workaround until the Roslyn team fixes the issue.
