### PR TITLE
Fix IntelliSense dialog low performance

### DIFF
--- a/VsIntegration/AutoComplete/IntellisensePresenter/CompletionSessionView.xaml
+++ b/VsIntegration/AutoComplete/IntellisensePresenter/CompletionSessionView.xaml
@@ -27,11 +27,11 @@
             <RowDefinition Height="auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <Border Background="White" BorderBrush="#FF828790" BorderThickness="1,1,1,0" Visibility="{Binding Session.SelectedCompletionSet.StatusText, Mode=OneWay, Converter={StaticResource ResourceKey=text2Visibility}}">
+        <Border Grid.Row="0" Grid.Column="0" Background="White" BorderBrush="#FF828790" BorderThickness="1,1,1,0" Visibility="{Binding Session.SelectedCompletionSet.StatusText, Mode=OneWay, Converter={StaticResource ResourceKey=text2Visibility}}">
             <TextBlock Text="{Binding Session.SelectedCompletionSet.StatusText, Mode=OneWay}" Padding="5,3,5,3" FontStyle="Italic" />
         </Border>
 
-        <ListBox x:Name="listViewCompletions" Grid.Row="1"
+        <ListBox x:Name="listViewCompletions" Grid.Row="1" Grid.Column="0" 
                      ItemTemplate="{DynamicResource ItemDataTemplate}"
                  ItemsSource="{Binding Session.SelectedCompletionSet.Completions}"               
                  MouseDoubleClick="ListView_MouseDoubleClick" 

--- a/VsIntegration/AutoComplete/IntellisensePresenter/CompletionSessionView.xaml
+++ b/VsIntegration/AutoComplete/IntellisensePresenter/CompletionSessionView.xaml
@@ -19,30 +19,25 @@
         </DataTemplate>
         <IntellisensePresenter:Text2Visibility x:Key="text2Visibility" />
     </UserControl.Resources>
-    <Border>
-        <ScrollViewer Name="scrollViewer" Background="Transparent" IsDeferredScrollingEnabled="False" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
-            <Grid PreviewMouseWheel="Grid_PreviewMouseWheel">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="auto" />
-                    <!--<ColumnDefinition />-->
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="auto" />
-                    <RowDefinition Height="auto" />
-                </Grid.RowDefinitions>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Border Background="White" BorderBrush="#FF828790" BorderThickness="1,1,1,0" Visibility="{Binding Session.SelectedCompletionSet.StatusText, Mode=OneWay, Converter={StaticResource ResourceKey=text2Visibility}}">
+            <TextBlock Text="{Binding Session.SelectedCompletionSet.StatusText, Mode=OneWay}" Padding="5,3,5,3" FontStyle="Italic" />
+        </Border>
 
-                <Border Background="White" BorderBrush="#FF828790" BorderThickness="1,1,1,0" Visibility="{Binding Session.SelectedCompletionSet.StatusText, Mode=OneWay, Converter={StaticResource ResourceKey=text2Visibility}}">
-                    <TextBlock Text="{Binding Session.SelectedCompletionSet.StatusText, Mode=OneWay}" Padding="5,3,5,3" FontStyle="Italic" />
-                </Border>
-
-                <ListBox x:Name="listViewCompletions" Grid.Row="1"
+        <ListBox x:Name="listViewCompletions" Grid.Row="1"
                      ItemTemplate="{DynamicResource ItemDataTemplate}"
                  ItemsSource="{Binding Session.SelectedCompletionSet.Completions}"               
                  MouseDoubleClick="ListView_MouseDoubleClick" 
                  SelectionChanged="ListView_SelectionChanged" 
-                 MouseLeftButtonDown="listViewCompletions_MouseLeftButtonDown">
-                </ListBox>
-            </Grid>
-        </ScrollViewer>
-    </Border>
+                 MouseLeftButtonDown="listViewCompletions_MouseLeftButtonDown"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto" 
+                 ScrollViewer.HorizontalScrollBarVisibility="Auto" />
+    </Grid>
 </UserControl>

--- a/VsIntegration/AutoComplete/IntellisensePresenter/CompletionSessionView.xaml.cs
+++ b/VsIntegration/AutoComplete/IntellisensePresenter/CompletionSessionView.xaml.cs
@@ -70,11 +70,5 @@ namespace TechTalk.SpecFlow.VsIntegration.AutoComplete.IntellisensePresenter
         {
             this.SurrenderFocus();
         }
-
-        private void Grid_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
-        {
-            this.scrollViewer.ScrollToVerticalOffset(scrollViewer.VerticalOffset - e.Delta);
-            e.Handled = true;
-        }
     }
 }


### PR DESCRIPTION
Currently in intellisense dialog in grid with listbox has height="Auto". However, this property does not limit size of listbox. It means that list listbox virtualization is not used, as well as its scroll viewer. And in case of huge amount of steps it takes TOO long for dialog to appear (on our project - up to 10 seconds).
It is fixed by using height="*" instead.

Before (red border - boundaries of listbox, height - something about 28000 px):
![listbox_before](https://cloud.githubusercontent.com/assets/17177729/22224319/dcbe1758-e1c6-11e6-8a54-99621ca71105.png)