### PR TITLE
Add ability to limit maximum amount of step instances intellisense suggestions

### DIFF
--- a/IdeIntegration/Options/IntegrationOptions.cs
+++ b/IdeIntegration/Options/IntegrationOptions.cs
@@ -5,6 +5,7 @@
         public bool EnableSyntaxColoring { get; set; }
         public bool EnableOutlining { get; set; }
         public bool EnableIntelliSense { get; set; }
+        public bool LimitStepInstancesSuggestions { get; set; }
         public int MaxStepInstancesSuggestions { get; set; }
         public bool EnableAnalysis { get; set; }
         public bool EnableTableAutoFormat { get; set; }

--- a/IdeIntegration/Options/IntegrationOptions.cs
+++ b/IdeIntegration/Options/IntegrationOptions.cs
@@ -5,6 +5,7 @@
         public bool EnableSyntaxColoring { get; set; }
         public bool EnableOutlining { get; set; }
         public bool EnableIntelliSense { get; set; }
+        public int MaxStepInstancesSuggestions { get; set; }
         public bool EnableAnalysis { get; set; }
         public bool EnableTableAutoFormat { get; set; }
         public bool EnableStepMatchColoring { get; set; }

--- a/VsIntegration/AutoComplete/GherkinStepCompletionSource.cs
+++ b/VsIntegration/AutoComplete/GherkinStepCompletionSource.cs
@@ -35,7 +35,8 @@ namespace TechTalk.SpecFlow.VsIntegration.AutoComplete
             if (!IntegrationOptionsProvider.GetOptions().EnableIntelliSense)
                 return null;
 
-            return new GherkinStepCompletionSource(textBuffer, GherkinLanguageServiceFactory.GetLanguageService(textBuffer), Tracer);
+            int maxStepSuggestions = IntegrationOptionsProvider.GetOptions().MaxStepInstancesSuggestions;
+            return new GherkinStepCompletionSource(textBuffer, GherkinLanguageServiceFactory.GetLanguageService(textBuffer), Tracer, maxStepSuggestions);
         }
     }
 
@@ -45,12 +46,14 @@ namespace TechTalk.SpecFlow.VsIntegration.AutoComplete
         private readonly ITextBuffer textBuffer;
         private readonly GherkinLanguageService languageService;
         private readonly IIdeTracer tracer;
+        private readonly int maxStepInstancesSuggestions;
 
-        public GherkinStepCompletionSource(ITextBuffer textBuffer, GherkinLanguageService languageService, IIdeTracer tracer)
+        public GherkinStepCompletionSource(ITextBuffer textBuffer, GherkinLanguageService languageService, IIdeTracer tracer, int maxStepInstancesSuggestions)
         {
             this.textBuffer = textBuffer;
             this.languageService = languageService;
             this.tracer = tracer;
+            this.maxStepInstancesSuggestions = maxStepInstancesSuggestions;
         }
 
         public void AugmentCompletionSession(ICompletionSession session, IList<CompletionSet> completionSets)
@@ -95,7 +98,8 @@ namespace TechTalk.SpecFlow.VsIntegration.AutoComplete
                     displayName, 
                     applicableTo, 
                     completions, 
-                    null);
+                    null,
+                    maxStepInstancesSuggestions);
 
                 if (!string.IsNullOrEmpty(statusText))
                     completionSet.StatusText = statusText;

--- a/VsIntegration/AutoComplete/GherkinStepCompletionSource.cs
+++ b/VsIntegration/AutoComplete/GherkinStepCompletionSource.cs
@@ -32,11 +32,13 @@ namespace TechTalk.SpecFlow.VsIntegration.AutoComplete
 
         public ICompletionSource TryCreateCompletionSource(ITextBuffer textBuffer)
         {
-            if (!IntegrationOptionsProvider.GetOptions().EnableIntelliSense)
+            var options = IntegrationOptionsProvider.GetOptions();
+            if (!options.EnableIntelliSense)
                 return null;
 
-            int maxStepSuggestions = IntegrationOptionsProvider.GetOptions().MaxStepInstancesSuggestions;
-            return new GherkinStepCompletionSource(textBuffer, GherkinLanguageServiceFactory.GetLanguageService(textBuffer), Tracer, maxStepSuggestions);
+            bool limitStepInstancesSuggestions = options.LimitStepInstancesSuggestions;
+            int maxStepSuggestions = options.MaxStepInstancesSuggestions;
+            return new GherkinStepCompletionSource(textBuffer, GherkinLanguageServiceFactory.GetLanguageService(textBuffer), Tracer, limitStepInstancesSuggestions, maxStepSuggestions);
         }
     }
 
@@ -46,13 +48,15 @@ namespace TechTalk.SpecFlow.VsIntegration.AutoComplete
         private readonly ITextBuffer textBuffer;
         private readonly GherkinLanguageService languageService;
         private readonly IIdeTracer tracer;
+        private readonly bool limitStepInstancesSuggestions;
         private readonly int maxStepInstancesSuggestions;
 
-        public GherkinStepCompletionSource(ITextBuffer textBuffer, GherkinLanguageService languageService, IIdeTracer tracer, int maxStepInstancesSuggestions)
+        public GherkinStepCompletionSource(ITextBuffer textBuffer, GherkinLanguageService languageService, IIdeTracer tracer, bool limitStepInstancesSuggestions, int maxStepInstancesSuggestions)
         {
             this.textBuffer = textBuffer;
             this.languageService = languageService;
             this.tracer = tracer;
+            this.limitStepInstancesSuggestions = limitStepInstancesSuggestions;
             this.maxStepInstancesSuggestions = maxStepInstancesSuggestions;
         }
 
@@ -99,6 +103,7 @@ namespace TechTalk.SpecFlow.VsIntegration.AutoComplete
                     applicableTo, 
                     completions, 
                     null,
+                    limitStepInstancesSuggestions,
                     maxStepInstancesSuggestions);
 
                 if (!string.IsNullOrEmpty(statusText))

--- a/VsIntegration/AutoComplete/HierarchicalCompletionSet.cs
+++ b/VsIntegration/AutoComplete/HierarchicalCompletionSet.cs
@@ -1,22 +1,29 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
+using TechTalk.SpecFlow.Bindings;
 using TechTalk.SpecFlow.VsIntegration.StepSuggestions;
 
 namespace TechTalk.SpecFlow.VsIntegration.AutoComplete
 {
     internal class HierarchicalCompletionSet : CustomCompletionSet
     {
-        public HierarchicalCompletionSet()
+        public HierarchicalCompletionSet(int maxStepInstances)
         {
             PrefixMatch = false;
+            _maxStepInstances = maxStepInstances;
         }
 
-        public HierarchicalCompletionSet(string moniker, string displayName, ITrackingSpan applicableTo, IEnumerable<Completion> completions, IEnumerable<Completion> completionBuilders) : base(moniker, displayName, applicableTo, completions, completionBuilders)
+        public HierarchicalCompletionSet(string moniker, string displayName, ITrackingSpan applicableTo, IEnumerable<Completion> completions, IEnumerable<Completion> completionBuilders, int maxStepInstances)
+            : base(moniker, displayName, applicableTo, completions, completionBuilders)
         {
             PrefixMatch = false;
+            _maxStepInstances = maxStepInstances;
         }
+
+        private readonly int _maxStepInstances;
 
         protected override bool DoesCompletionMatchApplicabilityText(Completion completion, string filterText, CompletionMatchType matchType, bool caseSensitive)
         {
@@ -30,6 +37,44 @@ namespace TechTalk.SpecFlow.VsIntegration.AutoComplete
                 parentObjectAsGroup != null && 
                 parentObjectAsGroup.Suggestions
                     .Any(stepSuggestion => stepSuggestion.NativeSuggestionItem != null && DoesCompletionMatchApplicabilityText(stepSuggestion.NativeSuggestionItem, filterText, matchType, caseSensitive));
+        }
+
+        protected override Predicate<Completion> GetFilterPredicate(string filterText, CompletionMatchType matchType, bool caseSensitive)
+        {
+            var basePredicate = base.GetFilterPredicate(filterText, matchType, caseSensitive);
+            return LimitStepInstances(_maxStepInstances, basePredicate);
+        }
+
+        /// <summary>
+        /// Returns predicate to limit quantity of step instances suggestions for each step template
+        /// </summary>
+        private Predicate<Completion> LimitStepInstances(int stepInstancesCount, Predicate<Completion> basePredicate)
+        {
+            int stepInstancesCounter = 0;
+
+            return completion =>
+            {
+                if (!basePredicate.Invoke(completion))
+                {
+                    return false;
+                }
+
+                //If completion is step instance - increase counter, else - reset.
+                object parentObject;
+                completion.Properties.TryGetProperty("parentObject", out parentObject);
+                bool isStepInstance = parentObject is StepInstance;
+
+                if (isStepInstance)
+                {
+                    stepInstancesCounter++;
+                }
+                else
+                {
+                    stepInstancesCounter = 0;
+                }
+
+                return stepInstancesCounter <= stepInstancesCount;
+            };
         }
     }
 }

--- a/VsIntegration/Options/IntegrationOptionsProvider.cs
+++ b/VsIntegration/Options/IntegrationOptionsProvider.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.VsIntegration.Options
         public const bool EnableSyntaxColoringDefaultValue = true;
         public const bool EnableOutliningDefaultValue = true;
         public const bool EnableIntelliSenseDefaultValue = true;
-        public const int MaxStepInstancesSuggestionsDefaultValue = 5;
+        public const string MaxStepInstancesSuggestionsDefaultValue = "";
         public const bool EnableAnalysisDefaultValue = true;
         public const bool EnableTableAutoFormatDefaultValue = true;
         public const bool EnableStepMatchColoringDefaultValue = true;
@@ -50,12 +50,14 @@ namespace TechTalk.SpecFlow.VsIntegration.Options
             if (options != null)
                 return options;
 
+            int maxStepInstancesSuggestions;
             options = new IntegrationOptions
                                           {
                                               EnableSyntaxColoring = GetGeneralOption(dte, "EnableSyntaxColoring", EnableSyntaxColoringDefaultValue),
                                               EnableOutlining = GetGeneralOption(dte, "EnableOutlining", EnableOutliningDefaultValue),
                                               EnableIntelliSense = GetGeneralOption(dte, "EnableIntelliSense", EnableIntelliSenseDefaultValue),
-                                              MaxStepInstancesSuggestions = GetGeneralOption(dte, "MaxStepInstancesSuggestions", MaxStepInstancesSuggestionsDefaultValue),
+                                              LimitStepInstancesSuggestions = int.TryParse(GetGeneralOption(dte, "MaxStepInstancesSuggestions", MaxStepInstancesSuggestionsDefaultValue), out maxStepInstancesSuggestions),
+                                              MaxStepInstancesSuggestions = maxStepInstancesSuggestions,
                                               EnableAnalysis = GetGeneralOption(dte, "EnableAnalysis", EnableAnalysisDefaultValue),
                                               EnableTableAutoFormat = GetGeneralOption(dte, "EnableTableAutoFormat", EnableTableAutoFormatDefaultValue),
                                               EnableStepMatchColoring = GetGeneralOption(dte, "EnableStepMatchColoring", EnableStepMatchColoringDefaultValue),

--- a/VsIntegration/Options/IntegrationOptionsProvider.cs
+++ b/VsIntegration/Options/IntegrationOptionsProvider.cs
@@ -19,6 +19,7 @@ namespace TechTalk.SpecFlow.VsIntegration.Options
         public const bool EnableSyntaxColoringDefaultValue = true;
         public const bool EnableOutliningDefaultValue = true;
         public const bool EnableIntelliSenseDefaultValue = true;
+        public const int MaxStepInstancesSuggestionsDefaultValue = 5;
         public const bool EnableAnalysisDefaultValue = true;
         public const bool EnableTableAutoFormatDefaultValue = true;
         public const bool EnableStepMatchColoringDefaultValue = true;
@@ -54,6 +55,7 @@ namespace TechTalk.SpecFlow.VsIntegration.Options
                                               EnableSyntaxColoring = GetGeneralOption(dte, "EnableSyntaxColoring", EnableSyntaxColoringDefaultValue),
                                               EnableOutlining = GetGeneralOption(dte, "EnableOutlining", EnableOutliningDefaultValue),
                                               EnableIntelliSense = GetGeneralOption(dte, "EnableIntelliSense", EnableIntelliSenseDefaultValue),
+                                              MaxStepInstancesSuggestions = GetGeneralOption(dte, "MaxStepInstancesSuggestions", MaxStepInstancesSuggestionsDefaultValue),
                                               EnableAnalysis = GetGeneralOption(dte, "EnableAnalysis", EnableAnalysisDefaultValue),
                                               EnableTableAutoFormat = GetGeneralOption(dte, "EnableTableAutoFormat", EnableTableAutoFormatDefaultValue),
                                               EnableStepMatchColoring = GetGeneralOption(dte, "EnableStepMatchColoring", EnableStepMatchColoringDefaultValue),

--- a/VsIntegration/Options/OptionsPageGeneral.cs
+++ b/VsIntegration/Options/OptionsPageGeneral.cs
@@ -61,6 +61,12 @@ namespace TechTalk.SpecFlow.VsIntegration.Options
         public bool EnableIntelliSense { get; set; }
 
         [Category("Editor Settings")]
+        [Description("Limit quantity of IntelliSense step instances suggestions for each step template.")]
+        [DisplayName(@"Max Step Instances Suggestions")]
+        [DefaultValue(IntegrationOptionsProvider.MaxStepInstancesSuggestionsDefaultValue)]
+        public int MaxStepInstancesSuggestions { get; set; }
+
+        [Category("Editor Settings")]
         [Description("Controls whether the step definition match status should be indicated with a different color in the editor. (beta)")]
         [DisplayName(@"Enable Step Match Coloring")]
         [DefaultValue(IntegrationOptionsProvider.EnableStepMatchColoringDefaultValue)]
@@ -96,6 +102,7 @@ namespace TechTalk.SpecFlow.VsIntegration.Options
             EnableSyntaxColoring = IntegrationOptionsProvider.EnableSyntaxColoringDefaultValue;
             EnableOutlining = IntegrationOptionsProvider.EnableOutliningDefaultValue;
             EnableIntelliSense = IntegrationOptionsProvider.EnableIntelliSenseDefaultValue;
+            MaxStepInstancesSuggestions = IntegrationOptionsProvider.MaxStepInstancesSuggestionsDefaultValue;
             EnableTableAutoFormat = IntegrationOptionsProvider.EnableTableAutoFormatDefaultValue;
             EnableStepMatchColoring = IntegrationOptionsProvider.EnableStepMatchColoringDefaultValue;
             EnableTracing = IntegrationOptionsProvider.EnableTracingDefaultValue;

--- a/VsIntegration/Options/OptionsPageGeneral.cs
+++ b/VsIntegration/Options/OptionsPageGeneral.cs
@@ -55,18 +55,6 @@ namespace TechTalk.SpecFlow.VsIntegration.Options
         public bool EnableOutlining { get; set; }
 
         [Category("Editor Settings")]
-        [Description("Controls whether completion lists should be displayed for the feature files.")]
-        [DisplayName(@"Enable IntelliSense")]
-        [DefaultValue(IntegrationOptionsProvider.EnableIntelliSenseDefaultValue)]
-        public bool EnableIntelliSense { get; set; }
-
-        [Category("Editor Settings")]
-        [Description("Limit quantity of IntelliSense step instances suggestions for each step template.")]
-        [DisplayName(@"Max Step Instances Suggestions")]
-        [DefaultValue(IntegrationOptionsProvider.MaxStepInstancesSuggestionsDefaultValue)]
-        public int MaxStepInstancesSuggestions { get; set; }
-
-        [Category("Editor Settings")]
         [Description("Controls whether the step definition match status should be indicated with a different color in the editor. (beta)")]
         [DisplayName(@"Enable Step Match Coloring")]
         [DefaultValue(IntegrationOptionsProvider.EnableStepMatchColoringDefaultValue)]
@@ -77,6 +65,34 @@ namespace TechTalk.SpecFlow.VsIntegration.Options
         [DisplayName(@"Enable Table Formatting")]
         [DefaultValue(IntegrationOptionsProvider.EnableTableAutoFormatDefaultValue)]
         public bool EnableTableAutoFormat { get; set; }
+
+
+        [Category("IntelliSense")]
+        [Description("Controls whether completion lists should be displayed for the feature files.")]
+        [DisplayName(@"Enable IntelliSense")]
+        [DefaultValue(IntegrationOptionsProvider.EnableIntelliSenseDefaultValue)]
+        public bool EnableIntelliSense { get; set; }
+
+        private string _maxStepInstancesSuggestions = String.Empty;
+        [Category("IntelliSense")]
+        [Description("Limit quantity of IntelliSense step instances suggestions for each step template.")]
+        [DisplayName(@"Max Step Instances Suggestions")]
+        [DefaultValue(IntegrationOptionsProvider.MaxStepInstancesSuggestionsDefaultValue)]
+        public string MaxStepInstancesSuggestions {
+            get { return _maxStepInstancesSuggestions; }
+            set
+            {
+                int parsedValue;
+                if (int.TryParse(value, out parsedValue) && parsedValue >= 0)
+                {
+                    _maxStepInstancesSuggestions = parsedValue.ToString();
+                }
+                else
+                {
+                    _maxStepInstancesSuggestions = string.Empty;
+                }
+            }
+        }
 
         [Category("Tracing")]
         [Description("Controls whether diagnostic trace messages should be emitted to the output window.")]


### PR DESCRIPTION
Problem is that when steps are highly reused, intellisense dialog becomes too messy, since per each step template 10-20 step instances are suggested. It makes much harder to find required step.
Here how it looks for our project:
![intellisense_items](https://cloud.githubusercontent.com/assets/17177729/22226185/f9686eec-e1cd-11e6-9e1a-6ba3f5ae763c.png)


This PR adds ability to limit quantity of step instances per each step template.