### PR TITLE
Add basic FormatDocument command support.

### DIFF
--- a/VsIntegration/EditorCommands/EditorCommandFilter.cs
+++ b/VsIntegration/EditorCommands/EditorCommandFilter.cs
@@ -30,14 +30,16 @@ namespace TechTalk.SpecFlow.VsIntegration.EditorCommands
         private readonly RunScenariosCommand runScenariosCommand;
         private readonly FormatTableCommand formatTableCommand;
         private readonly CommentUncommentCommand commentUncommentCommand;
+        private readonly FormatDocumentCommand formatDocumentCommand;
 
-        public EditorCommandFilter(IIdeTracer tracer, IGoToStepDefinitionCommand goToStepDefinitionCommand, DebugScenariosCommand debugScenariosCommand, RunScenariosCommand runScenariosCommand, FormatTableCommand formatTableCommand, CommentUncommentCommand commentUncommentCommand)
+        public EditorCommandFilter(IIdeTracer tracer, IGoToStepDefinitionCommand goToStepDefinitionCommand, DebugScenariosCommand debugScenariosCommand, RunScenariosCommand runScenariosCommand, FormatTableCommand formatTableCommand, CommentUncommentCommand commentUncommentCommand, FormatDocumentCommand formatDocumentCommand)
         {
             this.goToStepDefinitionCommand = goToStepDefinitionCommand;
             this.debugScenariosCommand = debugScenariosCommand;
             this.runScenariosCommand = runScenariosCommand;
             this.formatTableCommand = formatTableCommand;
             this.commentUncommentCommand = commentUncommentCommand;
+            this.formatDocumentCommand = formatDocumentCommand;
             this.tracer = tracer;
         }
 
@@ -74,6 +76,7 @@ namespace TechTalk.SpecFlow.VsIntegration.EditorCommands
                     case VSConstants.VSStd2KCmdID.COMMENTBLOCK:
                     case VSConstants.VSStd2KCmdID.UNCOMMENT_BLOCK:
                     case VSConstants.VSStd2KCmdID.UNCOMMENTBLOCK:
+                    case VSConstants.VSStd2KCmdID.FORMATDOCUMENT:
                         return true;
                 }
             }
@@ -152,6 +155,10 @@ namespace TechTalk.SpecFlow.VsIntegration.EditorCommands
                     case VSConstants.VSStd2KCmdID.UNCOMMENT_BLOCK:
                     case VSConstants.VSStd2KCmdID.UNCOMMENTBLOCK:
                         if (commentUncommentCommand.CommentOrUncommentSelection(editorContext, CommentUncommentAction.Uncomment))
+                            return true;
+                        break;
+                    case VSConstants.VSStd2KCmdID.FORMATDOCUMENT:
+                        if (formatDocumentCommand.FormatDocument(editorContext))
                             return true;
                         break;
                 }

--- a/VsIntegration/EditorCommands/FormatDocumentCommand.cs
+++ b/VsIntegration/EditorCommands/FormatDocumentCommand.cs
@@ -1,0 +1,290 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.Text;
+using TechTalk.SpecFlow.Parser;
+using TechTalk.SpecFlow.VsIntegration.LanguageService;
+
+namespace TechTalk.SpecFlow.VsIntegration.EditorCommands
+{
+    internal class FormatDocumentCommand
+    {
+        private const string FeatureIndent = "";
+        private const string ScenarioIndent = "";
+        private const string StepIndent = "\t";
+        private const string TableIndent = "\t\t";
+        private const string MultilineIndent = "\t\t";
+        private const string ExampleIndent = "\t";
+
+        private const int LineBreaksBeforeScenario = 1;
+        private const int LineBreaksBeforeExamples = 1;
+        private const int LineBreaksBeforeFeature = 0;
+
+        private const bool NormalizeLineBreaks = true;
+
+        private const string CommentSymbol = "#";
+        private const string TableSeparator = "|";
+        private const string TagSymbol = "@";
+        private const string MultilineArgumentDelimeter = "\"\"\"";
+
+
+        public bool FormatDocument(GherkinEditorContext editorContext)
+        {
+            var dialect = GetDialect(editorContext.LanguageService);
+            var textSnapshot = editorContext.TextView.TextSnapshot;
+
+            var textLines = textSnapshot.Lines
+                .Select(line => line.GetText())
+                .ToList();
+
+            var formattedTextLines = FormatText(textLines, dialect);
+            ReplaceText(textSnapshot, formattedTextLines);
+
+            return true;
+        }
+
+        private void ReplaceText(ITextSnapshot textSnapshot, List<string> newTextLines)
+        {
+            //Replacing text line-by-line preserves scroll and caret position
+            using (var edit = textSnapshot.TextBuffer.CreateEdit())
+            {
+                var currentLines = textSnapshot.Lines.ToList();
+
+                int k;
+                //Replace line-by-line
+                for (k = 0; k < currentLines.Count && k < newTextLines.Count; k++)
+                {
+                    var line = currentLines[k];
+                    if (line.GetText() != newTextLines[k])
+                    {
+                        var span = new SnapshotSpan(line.Start, line.End);
+                        edit.Replace(span, newTextLines[k]);
+                    }
+                }
+
+                //Replace anything left
+                var lastLine = currentLines[k - 1];
+                var endSpan = new SnapshotSpan(lastLine.End, currentLines.Last().EndIncludingLineBreak);
+                string remainingText = newTextLines.Count > k
+                    ? Environment.NewLine + string.Join(Environment.NewLine, newTextLines.Skip(k))
+                    : string.Empty;
+                if (endSpan.GetText() != remainingText)
+                {
+                    edit.Replace(endSpan, remainingText);
+                }
+
+                edit.Apply();
+            }
+        }
+
+        private List<string> FormatText(List<string> textLines, GherkinDialect dialect)
+        {
+            var formattedTextLines = new List<string>();
+
+            var stringsToInsertBefore = new List<string>();
+            for (int i = 0; i < textLines.Count; i++)
+            {
+                string trimmedLine = textLines[i].Trim();
+
+                if (string.IsNullOrWhiteSpace(textLines[i]))
+                {
+                    if (!NormalizeLineBreaks)
+                    {
+                        formattedTextLines.AddRange(stringsToInsertBefore);
+                        stringsToInsertBefore.Clear();
+                        formattedTextLines.Add(string.Empty);
+                    }
+                }
+                else if (IsCommentLine(trimmedLine) || IsTagLine(trimmedLine))
+                {
+                    // Commment or tag lines should have same indent as following line,
+                    // that's why we put them to temporary collection
+                    stringsToInsertBefore.Add(trimmedLine);
+                }
+                else if (IsTableLine(trimmedLine))
+                {
+                    formattedTextLines.AddRange(stringsToInsertBefore.Select(str => TableIndent + str));
+                    stringsToInsertBefore.Clear();
+
+                    //Find whole table, and format it using FormatTableCommand.FormatTableString
+                    var tableLines = new List<string>();
+                    tableLines.Add(TableIndent + trimmedLine);
+                    while (i + 1 < textLines.Count && IsTableLine(textLines[i + 1]))
+                    {
+                        i++;
+                        tableLines.Add(textLines[i]);
+                    }
+                    var formattedTable =
+                        FormatTableCommand.FormatTableString(string.Join(Environment.NewLine, tableLines));
+                    formattedTextLines.AddRange(formattedTable.Split(new[] { Environment.NewLine },
+                        StringSplitOptions.None));
+                }
+                else if (IsMultilineDelimeterLine(trimmedLine))
+                {
+                    formattedTextLines.AddRange(stringsToInsertBefore.Select(str => MultilineIndent + str));
+                    stringsToInsertBefore.Clear();
+
+                    formattedTextLines.Add(MultilineIndent + trimmedLine);
+
+                    //Find original indent of multiline argument
+                    int whitespaces = 0;
+                    while (char.IsWhiteSpace(textLines[i][whitespaces]))
+                    {
+                        whitespaces++;
+                    }
+                    string originalIndent = textLines[i].Substring(0, whitespaces);
+
+                    while (!IsMultilineDelimeterLine(textLines[++i]))
+                    {
+                        string formattedLine;
+                        if (textLines[i].StartsWith(originalIndent))
+                        {
+                            //replace original indent with MultilineIndent
+                            formattedLine = MultilineIndent + textLines[i].Substring(originalIndent.Length).TrimEnd();
+                        }
+                        else
+                        {
+                            //invalid case - leave it as it is
+                            formattedLine = textLines[i];
+                        }
+                        formattedTextLines.Add(formattedLine);
+                    }
+
+                    formattedTextLines.Add(MultilineIndent + textLines[i].Trim());
+                }
+                else if (IsBlockLine(trimmedLine, dialect) || IsStepLine(trimmedLine, dialect))
+                {
+                    if (NormalizeLineBreaks)
+                    {
+                        int addLinesBefore = GetPreceedingLineBreaks(trimmedLine, dialect);
+                        for (int j = 0; j < addLinesBefore; j++)
+                        {
+                            formattedTextLines.Add(string.Empty);
+                        }
+                    }
+                    string indent = GetIndent(trimmedLine, dialect);
+
+                    formattedTextLines.AddRange(stringsToInsertBefore.Select(str => indent + str));
+                    stringsToInsertBefore.Clear();
+
+                    formattedTextLines.Add(indent + trimmedLine);
+                }
+                else
+                {
+                    //Other lines - leave unchanged
+                    formattedTextLines.AddRange(stringsToInsertBefore);
+                    stringsToInsertBefore.Clear();
+
+                    formattedTextLines.Add(textLines[i]);
+                }
+            }
+
+            formattedTextLines.AddRange(stringsToInsertBefore);
+            stringsToInsertBefore.Clear();
+            return formattedTextLines;
+        }
+
+        private string GetIndent(string line, GherkinDialect dialect)
+        {
+            if (IsBlockLine(line, dialect))
+            {
+                var keyword = GetBlockKeyword(line, dialect);
+                switch (keyword)
+                {
+                    case GherkinBlockKeyword.Scenario:
+                    case GherkinBlockKeyword.ScenarioOutline:
+                    case GherkinBlockKeyword.Background:
+                        return ScenarioIndent;
+
+                    case GherkinBlockKeyword.Examples:
+                        return ExampleIndent;
+
+                    case GherkinBlockKeyword.Feature:
+                        return FeatureIndent;
+                }
+            }
+            else if (IsStepLine(line, dialect))
+            {
+                return StepIndent;
+            }
+            else if (IsTableLine(line))
+            {
+                return TableIndent;
+            }
+
+            return string.Empty;
+        }
+
+        private int GetPreceedingLineBreaks(string line, GherkinDialect dialect)
+        {
+            if (IsBlockLine(line, dialect))
+            {
+                var keyword = GetBlockKeyword(line, dialect);
+                switch (keyword)
+                {
+                    case GherkinBlockKeyword.Scenario:
+                    case GherkinBlockKeyword.ScenarioOutline:
+                    case GherkinBlockKeyword.Background:
+                        return LineBreaksBeforeScenario;
+
+                    case GherkinBlockKeyword.Examples:
+                        return LineBreaksBeforeExamples;
+
+                    case GherkinBlockKeyword.Feature:
+                        return LineBreaksBeforeFeature;
+                }
+            }
+
+            return 0;
+        }
+
+
+        private GherkinDialect GetDialect(GherkinLanguageService languageService)
+        {
+            var fileScope = languageService.GetFileScope(waitForResult: false);
+            return fileScope != null
+                ? fileScope.GherkinDialect
+                : languageService.ProjectScope.GherkinDialectServices.GetDefaultDialect();
+        }
+
+        private bool IsBlockLine(string line, GherkinDialect dialect)
+        {
+            var trimmedLine = line.TrimStart();
+            return dialect.GetBlockKeywords().Any(keyword => trimmedLine.StartsWith(keyword));
+        }
+
+        private GherkinBlockKeyword GetBlockKeyword(string line, GherkinDialect dialect)
+        {
+            var trimmedLine = line.TrimStart();
+            return Enum.GetValues(typeof(GherkinBlockKeyword))
+                .Cast<GherkinBlockKeyword>()
+                .First(keyword => dialect.GetBlockKeywords(keyword).Any(word => trimmedLine.StartsWith(word)));
+        }
+
+        private bool IsStepLine(string line, GherkinDialect dialect)
+        {
+            var trimmedLine = line.TrimStart();
+            return dialect.GetStepKeywords().Any(keyword => trimmedLine.StartsWith(keyword));
+        }
+
+        private bool IsTableLine(string line)
+        {
+            return line.TrimStart().StartsWith(TableSeparator);
+        }
+
+        private bool IsCommentLine(string line)
+        {
+            return line.TrimStart().StartsWith(CommentSymbol);
+        }
+
+        private bool IsTagLine(string line)
+        {
+            return line.TrimStart().StartsWith(TagSymbol);
+        }
+
+        private bool IsMultilineDelimeterLine(string line)
+        {
+            return line.Trim() == MultilineArgumentDelimeter;
+        }
+    }
+}

--- a/VsIntegration/EditorCommands/FormatTableCommand.cs
+++ b/VsIntegration/EditorCommands/FormatTableCommand.cs
@@ -53,7 +53,7 @@ namespace TechTalk.SpecFlow.VsIntegration.EditorCommands
             return trimmedLine.StartsWith("|");
         }
 
-        private string FormatTableString(string oldTable)
+        internal static string FormatTableString(string oldTable)
         {
             const string escapedPipeString = "\\\0";
             oldTable = oldTable.Replace("\\|", escapedPipeString);
@@ -114,7 +114,7 @@ namespace TechTalk.SpecFlow.VsIntegration.EditorCommands
             return stringBuilder.ToString().Replace(escapedPipeString, "\\|");
         }
 
-        private string[] GetCells(string line)
+        private static string[] GetCells(string line)
         {
             line = line.Trim();
             if (line.StartsWith("|"))

--- a/VsIntegration/TechTalk.SpecFlow.VsIntegration.2013.csproj
+++ b/VsIntegration/TechTalk.SpecFlow.VsIntegration.2013.csproj
@@ -229,6 +229,7 @@
     <Compile Include="Commands\SpecFlowProjectSingleSelectionCommand.cs" />
     <Compile Include="EditorCommands\CommentUncommentCommand.cs" />
     <Compile Include="EditorCommands\EditorCommandFilter.cs" />
+    <Compile Include="EditorCommands\FormatDocumentCommand.cs" />
     <Compile Include="EditorCommands\FormatTableCommand.cs" />
     <Compile Include="EditorCommands\GherkinEditorContext.cs" />
     <Compile Include="EditorCommands\GherkinTextViewCreationListener.cs" />

--- a/VsIntegration/TechTalk.SpecFlow.VsIntegration.2015.csproj
+++ b/VsIntegration/TechTalk.SpecFlow.VsIntegration.2015.csproj
@@ -229,6 +229,7 @@
     <Compile Include="Commands\SpecFlowProjectSingleSelectionCommand.cs" />
     <Compile Include="EditorCommands\CommentUncommentCommand.cs" />
     <Compile Include="EditorCommands\EditorCommandFilter.cs" />
+    <Compile Include="EditorCommands\FormatDocumentCommand.cs" />
     <Compile Include="EditorCommands\FormatTableCommand.cs" />
     <Compile Include="EditorCommands\GherkinEditorContext.cs" />
     <Compile Include="EditorCommands\GherkinTextViewCreationListener.cs" />

--- a/VsIntegration/TechTalk.SpecFlow.VsIntegration.2017.csproj
+++ b/VsIntegration/TechTalk.SpecFlow.VsIntegration.2017.csproj
@@ -229,6 +229,7 @@
     <Compile Include="Commands\SpecFlowProjectSingleSelectionCommand.cs" />
     <Compile Include="EditorCommands\CommentUncommentCommand.cs" />
     <Compile Include="EditorCommands\EditorCommandFilter.cs" />
+    <Compile Include="EditorCommands\FormatDocumentCommand.cs" />
     <Compile Include="EditorCommands\FormatTableCommand.cs" />
     <Compile Include="EditorCommands\GherkinEditorContext.cs" />
     <Compile Include="EditorCommands\GherkinTextViewCreationListener.cs" />

--- a/VsIntegration/TechTalk.SpecFlow.VsIntegration.csproj
+++ b/VsIntegration/TechTalk.SpecFlow.VsIntegration.csproj
@@ -25,7 +25,6 @@
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
-	
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -43,12 +42,12 @@
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '12'">
     <AssemblyName>TechTalk.SpecFlow.VsIntegration.2013</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-	<StartProgram>C:\Program Files %28x86%29\Microsoft Visual Studio 12.0\Common7\IDE\devenv.exe</StartProgram>
+    <StartProgram>C:\Program Files %28x86%29\Microsoft Visual Studio 12.0\Common7\IDE\devenv.exe</StartProgram>
   </PropertyGroup>
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '14'">
     <AssemblyName>TechTalk.SpecFlow.VsIntegration.2015</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-	<StartProgram>C:\Program Files %28x86%29\Microsoft Visual Studio 14.0\Common7\IDE\devenv.exe</StartProgram>
+    <StartProgram>C:\Program Files %28x86%29\Microsoft Visual Studio 14.0\Common7\IDE\devenv.exe</StartProgram>
   </PropertyGroup>
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '15'">
     <AssemblyName>TechTalk.SpecFlow.VsIntegration.2017</AssemblyName>
@@ -66,8 +65,8 @@
     <DeployExtension>True</DeployExtension>
     <Prefer32Bit>false</Prefer32Bit>
     <PlatformTarget>x86</PlatformTarget>
-	<StartAction>Program</StartAction>
-	<StartArguments>/RootSuffix Exp</StartArguments>
+    <StartAction>Program</StartAction>
+    <StartArguments>/RootSuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -226,6 +225,7 @@
     <Compile Include="Commands\SpecFlowProjectSingleSelectionCommand.cs" />
     <Compile Include="EditorCommands\CommentUncommentCommand.cs" />
     <Compile Include="EditorCommands\EditorCommandFilter.cs" />
+    <Compile Include="EditorCommands\FormatDocumentCommand.cs" />
     <Compile Include="EditorCommands\FormatTableCommand.cs" />
     <Compile Include="EditorCommands\GherkinEditorContext.cs" />
     <Compile Include="EditorCommands\GherkinTextViewCreationListener.cs" />


### PR DESCRIPTION
Add basic FormatDocument command  (Edit > Advanced > Format Document) support to gherkin editor. 
It does the following:
 - normalize indents (currently indent values are constants)
 - normalize line breaks
 - format all tables

[before.feature](https://github.com/techtalk/SpecFlow.VisualStudio/files/728357/before.feature.txt)
[after.feature](https://github.com/techtalk/SpecFlow.VisualStudio/files/728355/after.feature.txt)
