### PR TITLE
Fix for right-click context with Resharper 2017.1

### DIFF
--- a/TechTalk.SpecFlow.VsIntegration.Common.targets
+++ b/TechTalk.SpecFlow.VsIntegration.Common.targets
@@ -7,6 +7,7 @@
 		<VSCommonExtensionsPath Condition="'$(VisualStudioVersion)' == '14.0'">$(MSBuildExtensionsPath32)\..\Microsoft Visual Studio $(VisualStudioVersion)\Common7\IDE\CommonExtensions</VSCommonExtensionsPath>
 		<VSCommonExtensionsPath Condition="'$(VisualStudioVersion)' == '15.0' and exists('$(MSBuildProgramFiles32)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions')">$(MSBuildProgramFiles32)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions</VSCommonExtensionsPath>
 		<VSCommonExtensionsPath Condition="'$(VisualStudioVersion)' == '15.0' and exists('$(MSBuildProgramFiles32)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions')">$(MSBuildProgramFiles32)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions</VSCommonExtensionsPath>
+		<VSCommonExtensionsPath Condition="'$(VisualStudioVersion)' == '15.0' and exists('$(MSBuildProgramFiles32)\Microsoft Visual Studio\2017\Professional\Common7\IDE\CommonExtensions')">$(MSBuildProgramFiles32)\Microsoft Visual Studio\2017\Professional\Common7\IDE\CommonExtensions</VSCommonExtensionsPath>
 	</PropertyGroup>
 	
 </Project>

--- a/VsIntegration/TestRunner/ReSharper6TestRunnerGateway.cs
+++ b/VsIntegration/TestRunner/ReSharper6TestRunnerGateway.cs
@@ -27,7 +27,19 @@ namespace TechTalk.SpecFlow.VsIntegration.TestRunner
 
     public class ReSharper6TestRunnerGateway : CommandBasedTestRunnerGateway
     {
+        private const int Resharper2017 = 108;
+
         private readonly int _currentVersion;
+
+        private string CommandToRun(bool debug)
+        {
+            if (debug)
+            {
+                return "Debug"; 
+            }
+
+            return _currentVersion >= Resharper2017 ? "RunFrom" : "Run";
+        }
 
         protected override string GetRunInCurrentContextCommand(bool debug)
         {
@@ -45,12 +57,7 @@ namespace TechTalk.SpecFlow.VsIntegration.TestRunner
                 commandFormat = "ReSharper.ReSharper_UnitTest{0}Context";
             }
 
-            if (debug)
-            {
-                return string.Format(commandFormat, "Debug");
-            }
-            return string.Format(commandFormat, "Run");
-
+            return string.Format(commandFormat, CommandToRun(debug));
         }
 
         public ReSharper6TestRunnerGateway(DTE dte, IIdeTracer tracer)


### PR DESCRIPTION
Adds right-click context support for Resharper 2017.1 (v108); the alias for 'ReSharper_UnitTest**Run**Context' [was changed](https://www.jetbrains.com/help/resharper/2017.1/Reference__Keyboard_Shortcuts.html) to 'ReSharper_UnitTest**RunFrom**Context'.

Currently running SpecFlow via right-click context with ReSharper 2017.1 will throw the exception 
```ReSharper6TestRunnerGateway: test tool error: System.Runtime.InteropServices.COMException (0x80004005): Command "ReSharper.ReSharper_UnitTestRunContext" is not valid.```
And display the modal error 'Object reference not set to an instance of an object.'