### PR TITLE
SpecFlowSingleFileGenerator does not run for feature files contained in projects of type "9A19103F-16F7-4668-BE54-9A1E7A4F7556"

### DIFF
--- a/VsIntegration/Bindings/Discovery/VsBindingRegistryBuilder.cs
+++ b/VsIntegration/Bindings/Discovery/VsBindingRegistryBuilder.cs
@@ -54,6 +54,10 @@ namespace TechTalk.SpecFlow.VsIntegration.Bindings.Discovery
                     parts.AddRange(bindingClassIncludingParts.Parts.OfType<CodeClass>());
                 }
 
+                // in Visual Studio 2017, CodeClass2.Parts is always empty, fall back to CodeClass2.Collection
+                // https://github.com/dotnet/roslyn/issues/21074
+                if (parts.Count == 0)
+                    parts.AddRange(bindingClassIncludingParts.Collection.OfType<CodeClass>());
 
                 var baseClass = GetBaseClass(codeClass);
 

--- a/VsIntegration/SingleFileGenerator/SpecFlowSingleFileGenerator.cs
+++ b/VsIntegration/SingleFileGenerator/SpecFlowSingleFileGenerator.cs
@@ -13,6 +13,8 @@ namespace TechTalk.SpecFlow.VsIntegration
 {
     [ComVisible(true)]
     [Guid("44F8C2E2-18A9-4B97-B830-6BCD0CAA161C")]
+	// Must register new project type which contains the new multi target model, https://github.com/aspnet/Tooling/issues/394#issuecomment-319244129
+    [CodeGeneratorRegistrationWithFileExtension(typeof(SpecFlowSingleFileGenerator), "C# SpecFlow Generator", "{9A19103F-16F7-4668-BE54-9A1E7A4F7556}", GeneratesDesignTimeSource = true, FileExtension = ".feature")]
     [CodeGeneratorRegistrationWithFileExtension(typeof(SpecFlowSingleFileGenerator), "C# SpecFlow Generator", vsContextGuids.vsContextGuidVCSProject, GeneratesDesignTimeSource = true, FileExtension = ".feature")]
     [CodeGeneratorRegistrationWithFileExtension(typeof(SpecFlowSingleFileGenerator), "VB.NET SpecFlow Generator", vsContextGuids.vsContextGuidVBProject, GeneratesDesignTimeSource = true, FileExtension = ".feature")]
     [CodeGeneratorRegistrationWithFileExtension(typeof(SpecFlowSingleFileGenerator), "Silverlight SpecFlow Generator", GuidList.vsContextGuidSilverlightProject, GeneratesDesignTimeSource = true, FileExtension = ".feature")]


### PR DESCRIPTION
When using Specflow in a test project which uses any of the new project model elements introduced in VS2017 such as multi-targeting, nuget package references, .NET standard projects, .NET core projects, etc the SpecFlowSingleFileGenerator will not run feature files contained within the project.

Furthermore, due to a bug in visual studio, CodeClass2.Parts is not always populated for these projects. This was preventing detection of already existant step bindings which was in turn causing the syntax highlighting in the feature files to appear as if they did not have step bindings (purple).

There is still one outstanding issue I noted with these projects, which is that even with the two issues above fixed, you still must alter the .cs file containing the step bindings in order for the proper syntax highlighting to appear in the feature file.

More details about the changes below:

1) Due to the new project type included in visual studio 2017 that represents the new project model which has built in nuget references, multi-targeting, etc...must register for that project type so that the SpecFlowSingleFileGenerator runs on feature files contained in those projects.
https://github.com/aspnet/Tooling/issues/394#issuecomment-319244129



2) Due to a bug in visual studio, must fall back to using CodeClass2.Collection when CodeClass2.Parts is empty
https://github.com/dotnet/roslyn/issues/21074