### PR TITLE
[Bug Report] Whitespace change indicate location of threading issue

### DIFF
--- a/VsIntegration/LanguageService/IdleTaskProcessingQueue.cs
+++ b/VsIntegration/LanguageService/IdleTaskProcessingQueue.cs
@@ -149,6 +149,8 @@ namespace TechTalk.SpecFlow.VsIntegration.LanguageService
             itemsAvailableEvent.Set();
             try
             {
+            
+            
                 thread.Join();
                 thread = null;
             }


### PR DESCRIPTION
I don't think Issues are enabled for this repository, so I am opening a PR with a whitespace change to report this. (I don't expect this to be merged).

There is a calling pattern here that could lend itself in Visual Studio deadlocking, and I wanted to report it to help. If there is a better mechanism that you would prefer I report this through, please let me know.

Here are some details:

When a Solution is closed, this Dispose method is run on the UI via the event handler for OnSolutionClosed (from ProjectScopeFactory). If there are background threads running, and they try and access the UI thread (for example, if a background thread is attempting to access some VS Project COM API, it will be marshalled onto the UI thread) while the UI thread is blocked, then this could result in a deadlock. The UI thread is blocked waiting for background threads to complete and background threads are blocked on access to UI thread.

Have to be careful that no background thread is accessing the UI thread when this lock is held (or maybe look at a way to handle the OnSolutionClosedEvent without blocking the UI thread).

Hope this is helpful - please let me know if there are other questions I might be able to help out with.