### PR TITLE
Changed all projects' C# version to 5.0

### DIFF
--- a/IdeIntegration/TechTalk.SpecFlow.IdeIntegration.csproj
+++ b/IdeIntegration/TechTalk.SpecFlow.IdeIntegration.csproj
@@ -30,6 +30,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/IdeIntegration/TechTalk.SpecFlow.IdeIntegration.csproj.DotSettings
+++ b/IdeIntegration/TechTalk.SpecFlow.IdeIntegration.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String></wpf:ResourceDictionary>

--- a/ItemTemplates/TechTalk.SpecFlow.VsIntegration.ItemTemplates.csproj
+++ b/ItemTemplates/TechTalk.SpecFlow.VsIntegration.ItemTemplates.csproj
@@ -55,6 +55,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/ItemTemplates/TechTalk.SpecFlow.VsIntegration.ItemTemplates.csproj.DotSettings
+++ b/ItemTemplates/TechTalk.SpecFlow.VsIntegration.ItemTemplates.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String></wpf:ResourceDictionary>

--- a/UnitTests/IdeIntegration.UnitTests/TechTalk.SpecFlow.IdeIntegration.UnitTests.csproj
+++ b/UnitTests/IdeIntegration.UnitTests/TechTalk.SpecFlow.IdeIntegration.UnitTests.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/UnitTests/IdeIntegration.UnitTests/TechTalk.SpecFlow.IdeIntegration.UnitTests.csproj.DotSettings
+++ b/UnitTests/IdeIntegration.UnitTests/TechTalk.SpecFlow.IdeIntegration.UnitTests.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String></wpf:ResourceDictionary>

--- a/VsIntegration/TechTalk.SpecFlow.VsIntegration.csproj
+++ b/VsIntegration/TechTalk.SpecFlow.VsIntegration.csproj
@@ -67,6 +67,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <StartAction>Program</StartAction>
     <StartArguments>/RootSuffix Exp</StartArguments>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/VsIntegration/TechTalk.SpecFlow.VsIntegration.csproj.DotSettings
+++ b/VsIntegration/TechTalk.SpecFlow.VsIntegration.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
Since the highest supported C# language version of Visual Studio 2013 is 5.0, setting the maximum C# version to 5.0 should improve writing code for multiple Visual Studio versions.

When set to "Default" and working with VS 2017, the IDE automatically uses C# 7.x.
It does not warn you about not supported code constructs (like String Concatenation) in older VS versions.

If the C# version is set to 5.0, the IDE can already tell you to not use newer constructs at writing time.
