### PR TITLE
upgraded all the project's version to 4.6 as VsIntegration.csproj

### DIFF
--- a/IdeIntegration/TechTalk.SpecFlow.IdeIntegration.csproj
+++ b/IdeIntegration/TechTalk.SpecFlow.IdeIntegration.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TechTalk.SpecFlow.IdeIntegration</RootNamespace>
     <AssemblyName>TechTalk.SpecFlow.IdeIntegration</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\specflow.snk</AssemblyOriginatorKeyFile>

--- a/ItemTemplates/TechTalk.SpecFlow.VsIntegration.ItemTemplates.csproj
+++ b/ItemTemplates/TechTalk.SpecFlow.VsIntegration.ItemTemplates.csproj
@@ -34,7 +34,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TechTalk.SpecFlow.VsIntegration.ItemTemplates</RootNamespace>
     <AssemblyName>TechTalk.SpecFlow.VsIntegration.ItemTemplates</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>

--- a/UnitTests/IdeIntegration.UnitTests/TechTalk.SpecFlow.IdeIntegration.UnitTests.csproj
+++ b/UnitTests/IdeIntegration.UnitTests/TechTalk.SpecFlow.IdeIntegration.UnitTests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TechTalk.SpecFlow.IdeIntegration.UnitTests</RootNamespace>
     <AssemblyName>TechTalk.SpecFlow.IdeIntegration.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>


### PR DESCRIPTION
it removes also a compilation warning for itemTemplates.csproj

it's useful to simplify the debug of the other issues related to the dll loading