### PR TITLE
Add FormatDocument command for feature files

### DIFF
--- a/IdeIntegration/Options/IntegrationOptions.cs
+++ b/IdeIntegration/Options/IntegrationOptions.cs
@@ -13,6 +13,11 @@
         public TestRunnerTool TestRunnerTool { get; set; }
         public bool DisableRegenerateFeatureFilePopupOnConfigChange { get; set; }
         public GenerationMode GenerationMode { get; set; }
+        public bool NormalizeLineBreaks { get; set; }
+        public int LineBreaksBeforeStep { get; set; }
+        public int LineBreaksBeforeScenario { get; set; }
+        public int LineBreaksBeforeExamples { get; set; }
+        public int LineBreaksBeforeFeature { get; set; }
     }
 
     public enum TestRunnerTool

--- a/VsIntegration/EditorCommands/EditorCommandFilter.cs
+++ b/VsIntegration/EditorCommands/EditorCommandFilter.cs
@@ -30,14 +30,16 @@ namespace TechTalk.SpecFlow.VsIntegration.EditorCommands
         private readonly RunScenariosCommand runScenariosCommand;
         private readonly FormatTableCommand formatTableCommand;
         private readonly CommentUncommentCommand commentUncommentCommand;
+        private readonly FormatDocumentCommand formatDocumentCommand;
 
-        public EditorCommandFilter(IIdeTracer tracer, IGoToStepDefinitionCommand goToStepDefinitionCommand, DebugScenariosCommand debugScenariosCommand, RunScenariosCommand runScenariosCommand, FormatTableCommand formatTableCommand, CommentUncommentCommand commentUncommentCommand)
+        public EditorCommandFilter(IIdeTracer tracer, IGoToStepDefinitionCommand goToStepDefinitionCommand, DebugScenariosCommand debugScenariosCommand, RunScenariosCommand runScenariosCommand, FormatTableCommand formatTableCommand, CommentUncommentCommand commentUncommentCommand, FormatDocumentCommand formatDocumentCommand)
         {
             this.goToStepDefinitionCommand = goToStepDefinitionCommand;
             this.debugScenariosCommand = debugScenariosCommand;
             this.runScenariosCommand = runScenariosCommand;
             this.formatTableCommand = formatTableCommand;
             this.commentUncommentCommand = commentUncommentCommand;
+            this.formatDocumentCommand = formatDocumentCommand;
             this.tracer = tracer;
         }
 
@@ -74,6 +76,7 @@ namespace TechTalk.SpecFlow.VsIntegration.EditorCommands
                     case VSConstants.VSStd2KCmdID.COMMENTBLOCK:
                     case VSConstants.VSStd2KCmdID.UNCOMMENT_BLOCK:
                     case VSConstants.VSStd2KCmdID.UNCOMMENTBLOCK:
+                    case VSConstants.VSStd2KCmdID.FORMATDOCUMENT:
                         return true;
                 }
             }
@@ -152,6 +155,10 @@ namespace TechTalk.SpecFlow.VsIntegration.EditorCommands
                     case VSConstants.VSStd2KCmdID.UNCOMMENT_BLOCK:
                     case VSConstants.VSStd2KCmdID.UNCOMMENTBLOCK:
                         if (commentUncommentCommand.CommentOrUncommentSelection(editorContext, CommentUncommentAction.Uncomment))
+                            return true;
+                        break;
+                    case VSConstants.VSStd2KCmdID.FORMATDOCUMENT:
+                        if (formatDocumentCommand.FormatDocument(editorContext))
                             return true;
                         break;
                 }

--- a/VsIntegration/EditorCommands/FormatDocumentCommand.cs
+++ b/VsIntegration/EditorCommands/FormatDocumentCommand.cs
@@ -7,311 +7,311 @@ using TechTalk.SpecFlow.VsIntegration.LanguageService;
 
 namespace TechTalk.SpecFlow.VsIntegration.EditorCommands
 {
-	internal class FormatDocumentCommand
-	{
-		private const string FeatureIndent = "";
-		private const string ScenarioIndent = "";
-		private const string StepIndent = "\t";
-		private const string TableIndent = "\t\t";
-		private const string MultilineIndent = "\t\t";
-		private const string ExampleIndent = "\t";
+    internal class FormatDocumentCommand
+    {
+        private const string FeatureIndent = "";
+        private const string ScenarioIndent = "";
+        private const string StepIndent = "\t";
+        private const string TableIndent = "\t\t";
+        private const string MultilineIndent = "\t\t";
+        private const string ExampleIndent = "\t";
 
-		private const string CommentSymbol = "#";
-		private const string TableSeparator = "|";
-		private const string TagSymbol = "@";
-		private const string MultilineArgumentDelimeter = "\"\"\"";
+        private const string CommentSymbol = "#";
+        private const string TableSeparator = "|";
+        private const string TagSymbol = "@";
+        private const string MultilineArgumentDelimeter = "\"\"\"";
 
-		private bool _normalizeLineBreaks;
-		private int _lineBreaksBeforeStep;
-		private int _lineBreaksBeforeScenario;
-		private int _lineBreaksBeforeExamples;
-		private int _lineBreaksBeforeFeature;
-
-
-		public bool FormatDocument(GherkinEditorContext editorContext)
-		{
-			ConfigureLineBreakOptions(editorContext);
-
-			var dialect = GetDialect(editorContext.LanguageService);
-			var textSnapshot = editorContext.TextView.TextSnapshot;
-
-			var textLines = textSnapshot.Lines
-				.Select(line => line.GetText())
-				.ToList();
-
-			var formattedTextLines = FormatText(textLines, dialect);
-			ReplaceText(textSnapshot, formattedTextLines);
-
-			return true;
-		}
-
-		private void ConfigureLineBreakOptions(GherkinEditorContext editorContext)
-		{
-			var options = editorContext.LanguageService.ProjectScope.IntegrationOptionsProvider.GetOptions();
-			_normalizeLineBreaks = options.NormalizeLineBreaks;
-			_lineBreaksBeforeStep = options.LineBreaksBeforeStep;
-			_lineBreaksBeforeScenario = options.LineBreaksBeforeScenario;
-			_lineBreaksBeforeExamples = options.LineBreaksBeforeExamples;
-			_lineBreaksBeforeFeature = options.LineBreaksBeforeFeature;
-		}
-
-		private void ReplaceText(ITextSnapshot textSnapshot, List<string> newTextLines)
-		{
-			//Replacing text line-by-line preserves scroll and caret position
-			using (var edit = textSnapshot.TextBuffer.CreateEdit())
-			{
-				var currentLines = textSnapshot.Lines.ToList();
-
-				int k;
-				//Replace line-by-line
-				for (k = 0; k < currentLines.Count && k < newTextLines.Count; k++)
-				{
-					var line = currentLines[k];
-					if (line.GetText() != newTextLines[k])
-					{
-						var span = new SnapshotSpan(line.Start, line.End);
-						edit.Replace(span, newTextLines[k]);
-					}
-				}
-
-				//Replace anything left
-				var lastLine = currentLines[k - 1];
-				var endSpan = new SnapshotSpan(lastLine.End, currentLines.Last().EndIncludingLineBreak);
-				string remainingText = newTextLines.Count > k
-					? Environment.NewLine + string.Join(Environment.NewLine, newTextLines.Skip(k))
-					: string.Empty;
-				if (endSpan.GetText() != remainingText)
-				{
-					edit.Replace(endSpan, remainingText);
-				}
-
-				edit.Apply();
-			}
-		}
-
-		private List<string> FormatText(List<string> textLines, GherkinDialect dialect)
-		{
-			var formattedTextLines = new List<string>();
-
-			var stringsToInsertBefore = new List<string>();
-			for (int i = 0; i < textLines.Count; i++)
-			{
-				string trimmedLine = textLines[i].Trim();
-
-				if (string.IsNullOrWhiteSpace(textLines[i]))
-				{
-					if (!_normalizeLineBreaks)
-					{
-						formattedTextLines.AddRange(stringsToInsertBefore);
-						stringsToInsertBefore.Clear();
-						formattedTextLines.Add(string.Empty);
-					}
-				}
-				else if (IsCommentLine(trimmedLine) || IsTagLine(trimmedLine))
-				{
-					// Commment or tag lines should have same indent as following line,
-					// that's why we put them to temporary collection
-					stringsToInsertBefore.Add(trimmedLine);
-				}
-				else if (IsTableLine(trimmedLine))
-				{
-					formattedTextLines.AddRange(stringsToInsertBefore.Select(str => TableIndent + str));
-					stringsToInsertBefore.Clear();
-
-					//Find whole table, and format it using FormatTableCommand.FormatTableString
-					var tableLines = new List<string>();
-					tableLines.Add(TableIndent + trimmedLine);
-					while (i + 1 < textLines.Count && IsTableLine(textLines[i + 1]))
-					{
-						i++;
-						tableLines.Add(textLines[i]);
-					}
-					var formattedTable =
-						FormatTableCommand.FormatTableString(string.Join(Environment.NewLine, tableLines));
-					formattedTextLines.AddRange(formattedTable.Split(new[] { Environment.NewLine },
-						StringSplitOptions.None));
-				}
-				else if (IsMultilineDelimeterLine(trimmedLine))
-				{
-					formattedTextLines.AddRange(stringsToInsertBefore.Select(str => MultilineIndent + str));
-					stringsToInsertBefore.Clear();
-
-					formattedTextLines.Add(MultilineIndent + trimmedLine);
-
-					//Find original indent of multiline argument
-					int whitespaces = 0;
-					while (char.IsWhiteSpace(textLines[i][whitespaces]))
-					{
-						whitespaces++;
-					}
-					string originalIndent = textLines[i].Substring(0, whitespaces);
-
-					while (!IsMultilineDelimeterLine(textLines[++i]))
-					{
-						string formattedLine;
-						if (textLines[i].StartsWith(originalIndent))
-						{
-							//replace original indent with MultilineIndent
-							formattedLine = MultilineIndent + textLines[i].Substring(originalIndent.Length).TrimEnd();
-						}
-						else
-						{
-							//invalid case - leave it as it is
-							formattedLine = textLines[i];
-						}
-						formattedTextLines.Add(formattedLine);
-					}
-
-					formattedTextLines.Add(MultilineIndent + textLines[i].Trim());
-				}
-				else if (IsBlockLine(trimmedLine, dialect) || IsStepLine(trimmedLine, dialect))
-				{
-					if (_normalizeLineBreaks)
-					{
-						int addLinesBefore = GetPreceedingLineBreaks(trimmedLine, dialect);
-						for (int j = 0; j < addLinesBefore; j++)
-						{
-							formattedTextLines.Add(string.Empty);
-						}
-					}
-					string indent = GetIndent(trimmedLine, dialect);
-
-					formattedTextLines.AddRange(stringsToInsertBefore.Select(str => indent + str));
-					stringsToInsertBefore.Clear();
-
-					formattedTextLines.Add(indent + trimmedLine);
-				}
-				else
-				{
-					//Other lines - leave unchanged
-					formattedTextLines.AddRange(stringsToInsertBefore);
-					stringsToInsertBefore.Clear();
-
-					formattedTextLines.Add(textLines[i]);
-				}
-			}
-
-			formattedTextLines.AddRange(stringsToInsertBefore);
-			stringsToInsertBefore.Clear();
-			return formattedTextLines;
-		}
-
-		private string GetIndent(string line, GherkinDialect dialect)
-		{
-			if (IsBlockLine(line, dialect))
-			{
-				var keyword = GetBlockKeyword(line, dialect);
-				switch (keyword)
-				{
-					case GherkinBlockKeyword.Scenario:
-					case GherkinBlockKeyword.ScenarioOutline:
-					case GherkinBlockKeyword.Background:
-						return ScenarioIndent;
-
-					case GherkinBlockKeyword.Examples:
-						return ExampleIndent;
-
-					case GherkinBlockKeyword.Feature:
-						return FeatureIndent;
-				}
-			}
-			else if (IsStepLine(line, dialect))
-			{
-				return GetConfiguredStepLineBreaksAndIndent();
-			}
-			else if (IsTableLine(line))
-			{
-				return TableIndent;
-			}
-
-			return string.Empty;
-		}
-
-		private string GetConfiguredStepLineBreaksAndIndent()
-		{
-			var str = string.Empty;
-
-			if (_normalizeLineBreaks)
-			{
-				for (var i = 0; i < _lineBreaksBeforeStep; i++)
-				{
-					str = str + Environment.NewLine;
-				}
-			}
-
-			return str + StepIndent;
-		}
-
-		private int GetPreceedingLineBreaks(string line, GherkinDialect dialect)
-		{
-			if (IsBlockLine(line, dialect))
-			{
-				var keyword = GetBlockKeyword(line, dialect);
-				switch (keyword)
-				{
-					case GherkinBlockKeyword.Scenario:
-					case GherkinBlockKeyword.ScenarioOutline:
-					case GherkinBlockKeyword.Background:
-						return _lineBreaksBeforeScenario;
-
-					case GherkinBlockKeyword.Examples:
-						return _lineBreaksBeforeExamples;
-
-					case GherkinBlockKeyword.Feature:
-						return _lineBreaksBeforeFeature;
-				}
-			}
-
-			return 0;
-		}
+        private bool _normalizeLineBreaks;
+        private int _lineBreaksBeforeStep;
+        private int _lineBreaksBeforeScenario;
+        private int _lineBreaksBeforeExamples;
+        private int _lineBreaksBeforeFeature;
 
 
-		private GherkinDialect GetDialect(GherkinLanguageService languageService)
-		{
-			var fileScope = languageService.GetFileScope(waitForResult: false);
-			return fileScope != null
-				? fileScope.GherkinDialect
-				: languageService.ProjectScope.GherkinDialectServices.GetDefaultDialect();
-		}
+        public bool FormatDocument(GherkinEditorContext editorContext)
+        {
+            ConfigureLineBreakOptions(editorContext);
 
-		private bool IsBlockLine(string line, GherkinDialect dialect)
-		{
-			var trimmedLine = line.TrimStart();
-			return dialect.GetBlockKeywords().Any(keyword => trimmedLine.StartsWith(keyword));
-		}
+            var dialect = GetDialect(editorContext.LanguageService);
+            var textSnapshot = editorContext.TextView.TextSnapshot;
 
-		private GherkinBlockKeyword GetBlockKeyword(string line, GherkinDialect dialect)
-		{
-			var trimmedLine = line.TrimStart();
-			return Enum.GetValues(typeof(GherkinBlockKeyword))
-				.Cast<GherkinBlockKeyword>()
-				.First(keyword => dialect.GetBlockKeywords(keyword).Any(word => trimmedLine.StartsWith(word)));
-		}
+            var textLines = textSnapshot.Lines
+                .Select(line => line.GetText())
+                .ToList();
 
-		private bool IsStepLine(string line, GherkinDialect dialect)
-		{
-			var trimmedLine = line.TrimStart();
-			return dialect.GetStepKeywords().Any(keyword => trimmedLine.StartsWith(keyword));
-		}
+            var formattedTextLines = FormatText(textLines, dialect);
+            ReplaceText(textSnapshot, formattedTextLines);
 
-		private bool IsTableLine(string line)
-		{
-			return line.TrimStart().StartsWith(TableSeparator);
-		}
+            return true;
+        }
 
-		private bool IsCommentLine(string line)
-		{
-			return line.TrimStart().StartsWith(CommentSymbol);
-		}
+        private void ConfigureLineBreakOptions(GherkinEditorContext editorContext)
+        {
+            var options = editorContext.LanguageService.ProjectScope.IntegrationOptionsProvider.GetOptions();
+            _normalizeLineBreaks = options.NormalizeLineBreaks;
+            _lineBreaksBeforeStep = options.LineBreaksBeforeStep;
+            _lineBreaksBeforeScenario = options.LineBreaksBeforeScenario;
+            _lineBreaksBeforeExamples = options.LineBreaksBeforeExamples;
+            _lineBreaksBeforeFeature = options.LineBreaksBeforeFeature;
+        }
 
-		private bool IsTagLine(string line)
-		{
-			return line.TrimStart().StartsWith(TagSymbol);
-		}
+        private void ReplaceText(ITextSnapshot textSnapshot, List<string> newTextLines)
+        {
+            //Replacing text line-by-line preserves scroll and caret position
+            using (var edit = textSnapshot.TextBuffer.CreateEdit())
+            {
+                var currentLines = textSnapshot.Lines.ToList();
 
-		private bool IsMultilineDelimeterLine(string line)
-		{
-			return line.Trim() == MultilineArgumentDelimeter;
-		}
-	}
+                int k;
+                //Replace line-by-line
+                for (k = 0; k < currentLines.Count && k < newTextLines.Count; k++)
+                {
+                    var line = currentLines[k];
+                    if (line.GetText() != newTextLines[k])
+                    {
+                        var span = new SnapshotSpan(line.Start, line.End);
+                        edit.Replace(span, newTextLines[k]);
+                    }
+                }
+
+                //Replace anything left
+                var lastLine = currentLines[k - 1];
+                var endSpan = new SnapshotSpan(lastLine.End, currentLines.Last().EndIncludingLineBreak);
+                string remainingText = newTextLines.Count > k
+                    ? Environment.NewLine + string.Join(Environment.NewLine, newTextLines.Skip(k))
+                    : string.Empty;
+                if (endSpan.GetText() != remainingText)
+                {
+                    edit.Replace(endSpan, remainingText);
+                }
+
+                edit.Apply();
+            }
+        }
+
+        private List<string> FormatText(List<string> textLines, GherkinDialect dialect)
+        {
+            var formattedTextLines = new List<string>();
+
+            var stringsToInsertBefore = new List<string>();
+            for (int i = 0; i < textLines.Count; i++)
+            {
+                string trimmedLine = textLines[i].Trim();
+
+                if (string.IsNullOrWhiteSpace(textLines[i]))
+                {
+                    if (!_normalizeLineBreaks)
+                    {
+                        formattedTextLines.AddRange(stringsToInsertBefore);
+                        stringsToInsertBefore.Clear();
+                        formattedTextLines.Add(string.Empty);
+                    }
+                }
+                else if (IsCommentLine(trimmedLine) || IsTagLine(trimmedLine))
+                {
+                    // Commment or tag lines should have same indent as following line,
+                    // that's why we put them to temporary collection
+                    stringsToInsertBefore.Add(trimmedLine);
+                }
+                else if (IsTableLine(trimmedLine))
+                {
+                    formattedTextLines.AddRange(stringsToInsertBefore.Select(str => TableIndent + str));
+                    stringsToInsertBefore.Clear();
+
+                    //Find whole table, and format it using FormatTableCommand.FormatTableString
+                    var tableLines = new List<string>();
+                    tableLines.Add(TableIndent + trimmedLine);
+                    while (i + 1 < textLines.Count && IsTableLine(textLines[i + 1]))
+                    {
+                        i++;
+                        tableLines.Add(textLines[i]);
+                    }
+                    var formattedTable =
+                        FormatTableCommand.FormatTableString(string.Join(Environment.NewLine, tableLines));
+                    formattedTextLines.AddRange(formattedTable.Split(new[] { Environment.NewLine },
+                        StringSplitOptions.None));
+                }
+                else if (IsMultilineDelimeterLine(trimmedLine))
+                {
+                    formattedTextLines.AddRange(stringsToInsertBefore.Select(str => MultilineIndent + str));
+                    stringsToInsertBefore.Clear();
+
+                    formattedTextLines.Add(MultilineIndent + trimmedLine);
+
+                    //Find original indent of multiline argument
+                    int whitespaces = 0;
+                    while (char.IsWhiteSpace(textLines[i][whitespaces]))
+                    {
+                        whitespaces++;
+                    }
+                    string originalIndent = textLines[i].Substring(0, whitespaces);
+
+                    while (!IsMultilineDelimeterLine(textLines[++i]))
+                    {
+                        string formattedLine;
+                        if (textLines[i].StartsWith(originalIndent))
+                        {
+                            //replace original indent with MultilineIndent
+                            formattedLine = MultilineIndent + textLines[i].Substring(originalIndent.Length).TrimEnd();
+                        }
+                        else
+                        {
+                            //invalid case - leave it as it is
+                            formattedLine = textLines[i];
+                        }
+                        formattedTextLines.Add(formattedLine);
+                    }
+
+                    formattedTextLines.Add(MultilineIndent + textLines[i].Trim());
+                }
+                else if (IsBlockLine(trimmedLine, dialect) || IsStepLine(trimmedLine, dialect))
+                {
+                    if (_normalizeLineBreaks)
+                    {
+                        int addLinesBefore = GetPreceedingLineBreaks(trimmedLine, dialect);
+                        for (int j = 0; j < addLinesBefore; j++)
+                        {
+                            formattedTextLines.Add(string.Empty);
+                        }
+                    }
+                    string indent = GetIndent(trimmedLine, dialect);
+
+                    formattedTextLines.AddRange(stringsToInsertBefore.Select(str => indent + str));
+                    stringsToInsertBefore.Clear();
+
+                    formattedTextLines.Add(indent + trimmedLine);
+                }
+                else
+                {
+                    //Other lines - leave unchanged
+                    formattedTextLines.AddRange(stringsToInsertBefore);
+                    stringsToInsertBefore.Clear();
+
+                    formattedTextLines.Add(textLines[i]);
+                }
+            }
+
+            formattedTextLines.AddRange(stringsToInsertBefore);
+            stringsToInsertBefore.Clear();
+            return formattedTextLines;
+        }
+
+        private string GetIndent(string line, GherkinDialect dialect)
+        {
+            if (IsBlockLine(line, dialect))
+            {
+                var keyword = GetBlockKeyword(line, dialect);
+                switch (keyword)
+                {
+                    case GherkinBlockKeyword.Scenario:
+                    case GherkinBlockKeyword.ScenarioOutline:
+                    case GherkinBlockKeyword.Background:
+                        return ScenarioIndent;
+
+                    case GherkinBlockKeyword.Examples:
+                        return ExampleIndent;
+
+                    case GherkinBlockKeyword.Feature:
+                        return FeatureIndent;
+                }
+            }
+            else if (IsStepLine(line, dialect))
+            {
+                return GetConfiguredStepLineBreaksAndIndent();
+            }
+            else if (IsTableLine(line))
+            {
+                return TableIndent;
+            }
+
+            return string.Empty;
+        }
+
+        private string GetConfiguredStepLineBreaksAndIndent()
+        {
+            var str = string.Empty;
+
+            if (_normalizeLineBreaks)
+            {
+                for (var i = 0; i < _lineBreaksBeforeStep; i++)
+                {
+                    str = str + Environment.NewLine;
+                }
+            }
+
+            return str + StepIndent;
+        }
+
+        private int GetPreceedingLineBreaks(string line, GherkinDialect dialect)
+        {
+            if (IsBlockLine(line, dialect))
+            {
+                var keyword = GetBlockKeyword(line, dialect);
+                switch (keyword)
+                {
+                    case GherkinBlockKeyword.Scenario:
+                    case GherkinBlockKeyword.ScenarioOutline:
+                    case GherkinBlockKeyword.Background:
+                        return _lineBreaksBeforeScenario;
+
+                    case GherkinBlockKeyword.Examples:
+                        return _lineBreaksBeforeExamples;
+
+                    case GherkinBlockKeyword.Feature:
+                        return _lineBreaksBeforeFeature;
+                }
+            }
+
+            return 0;
+        }
+
+
+        private GherkinDialect GetDialect(GherkinLanguageService languageService)
+        {
+            var fileScope = languageService.GetFileScope(waitForResult: false);
+            return fileScope != null
+                ? fileScope.GherkinDialect
+                : languageService.ProjectScope.GherkinDialectServices.GetDefaultDialect();
+        }
+
+        private bool IsBlockLine(string line, GherkinDialect dialect)
+        {
+            var trimmedLine = line.TrimStart();
+            return dialect.GetBlockKeywords().Any(keyword => trimmedLine.StartsWith(keyword));
+        }
+
+        private GherkinBlockKeyword GetBlockKeyword(string line, GherkinDialect dialect)
+        {
+            var trimmedLine = line.TrimStart();
+            return Enum.GetValues(typeof(GherkinBlockKeyword))
+                .Cast<GherkinBlockKeyword>()
+                .First(keyword => dialect.GetBlockKeywords(keyword).Any(word => trimmedLine.StartsWith(word)));
+        }
+
+        private bool IsStepLine(string line, GherkinDialect dialect)
+        {
+            var trimmedLine = line.TrimStart();
+            return dialect.GetStepKeywords().Any(keyword => trimmedLine.StartsWith(keyword));
+        }
+
+        private bool IsTableLine(string line)
+        {
+            return line.TrimStart().StartsWith(TableSeparator);
+        }
+
+        private bool IsCommentLine(string line)
+        {
+            return line.TrimStart().StartsWith(CommentSymbol);
+        }
+
+        private bool IsTagLine(string line)
+        {
+            return line.TrimStart().StartsWith(TagSymbol);
+        }
+
+        private bool IsMultilineDelimeterLine(string line)
+        {
+            return line.Trim() == MultilineArgumentDelimeter;
+        }
+    }
 }

--- a/VsIntegration/EditorCommands/FormatDocumentCommand.cs
+++ b/VsIntegration/EditorCommands/FormatDocumentCommand.cs
@@ -7,311 +7,311 @@ using TechTalk.SpecFlow.VsIntegration.LanguageService;
 
 namespace TechTalk.SpecFlow.VsIntegration.EditorCommands
 {
-    internal class FormatDocumentCommand
-    {
-        private const string FeatureIndent = "";
-        private const string ScenarioIndent = "";
-        private const string StepIndent = "\t";
-        private const string TableIndent = "\t\t";
-        private const string MultilineIndent = "\t\t";
-        private const string ExampleIndent = "\t";
+	internal class FormatDocumentCommand
+	{
+		private const string FeatureIndent = "";
+		private const string ScenarioIndent = "";
+		private const string StepIndent = "\t";
+		private const string TableIndent = "\t\t";
+		private const string MultilineIndent = "\t\t";
+		private const string ExampleIndent = "\t";
 
-        private const string CommentSymbol = "#";
-        private const string TableSeparator = "|";
-        private const string TagSymbol = "@";
-        private const string MultilineArgumentDelimeter = "\"\"\"";
+		private const string CommentSymbol = "#";
+		private const string TableSeparator = "|";
+		private const string TagSymbol = "@";
+		private const string MultilineArgumentDelimeter = "\"\"\"";
 
-        private bool _normalizeLineBreaks;
-        private int _lineBreaksBeforeStep;
-        private int _lineBreaksBeforeScenario;
-        private int _lineBreaksBeforeExamples;
-        private int _lineBreaksBeforeFeature;
-
-
-        public bool FormatDocument(GherkinEditorContext editorContext)
-        {
-            ConfigureLineBreakOptions(editorContext);
-
-            var dialect = GetDialect(editorContext.LanguageService);
-            var textSnapshot = editorContext.TextView.TextSnapshot;
-
-            var textLines = textSnapshot.Lines
-                .Select(line => line.GetText())
-                .ToList();
-
-            var formattedTextLines = FormatText(textLines, dialect);
-            ReplaceText(textSnapshot, formattedTextLines);
-
-            return true;
-        }
-
-        private void ConfigureLineBreakOptions(GherkinEditorContext editorContext)
-        {
-            var options = editorContext.LanguageService.ProjectScope.IntegrationOptionsProvider.GetOptions();
-            _normalizeLineBreaks = options.NormalizeLineBreaks;
-            _lineBreaksBeforeStep = options.LineBreaksBeforeStep;
-            _lineBreaksBeforeScenario = options.LineBreaksBeforeScenario;
-            _lineBreaksBeforeExamples = options.LineBreaksBeforeExamples;
-            _lineBreaksBeforeFeature = options.LineBreaksBeforeFeature;
-        }
-
-        private void ReplaceText(ITextSnapshot textSnapshot, List<string> newTextLines)
-        {
-            //Replacing text line-by-line preserves scroll and caret position
-            using (var edit = textSnapshot.TextBuffer.CreateEdit())
-            {
-                var currentLines = textSnapshot.Lines.ToList();
-
-                int k;
-                //Replace line-by-line
-                for (k = 0; k < currentLines.Count && k < newTextLines.Count; k++)
-                {
-                    var line = currentLines[k];
-                    if (line.GetText() != newTextLines[k])
-                    {
-                        var span = new SnapshotSpan(line.Start, line.End);
-                        edit.Replace(span, newTextLines[k]);
-                    }
-                }
-
-                //Replace anything left
-                var lastLine = currentLines[k - 1];
-                var endSpan = new SnapshotSpan(lastLine.End, currentLines.Last().EndIncludingLineBreak);
-                string remainingText = newTextLines.Count > k
-                    ? Environment.NewLine + string.Join(Environment.NewLine, newTextLines.Skip(k))
-                    : string.Empty;
-                if (endSpan.GetText() != remainingText)
-                {
-                    edit.Replace(endSpan, remainingText);
-                }
-
-                edit.Apply();
-            }
-        }
-
-        private List<string> FormatText(List<string> textLines, GherkinDialect dialect)
-        {
-            var formattedTextLines = new List<string>();
-
-            var stringsToInsertBefore = new List<string>();
-            for (int i = 0; i < textLines.Count; i++)
-            {
-                string trimmedLine = textLines[i].Trim();
-
-                if (string.IsNullOrWhiteSpace(textLines[i]))
-                {
-                    if (!_normalizeLineBreaks)
-                    {
-                        formattedTextLines.AddRange(stringsToInsertBefore);
-                        stringsToInsertBefore.Clear();
-                        formattedTextLines.Add(string.Empty);
-                    }
-                }
-                else if (IsCommentLine(trimmedLine) || IsTagLine(trimmedLine))
-                {
-                    // Commment or tag lines should have same indent as following line,
-                    // that's why we put them to temporary collection
-                    stringsToInsertBefore.Add(trimmedLine);
-                }
-                else if (IsTableLine(trimmedLine))
-                {
-                    formattedTextLines.AddRange(stringsToInsertBefore.Select(str => TableIndent + str));
-                    stringsToInsertBefore.Clear();
-
-                    //Find whole table, and format it using FormatTableCommand.FormatTableString
-                    var tableLines = new List<string>();
-                    tableLines.Add(TableIndent + trimmedLine);
-                    while (i + 1 < textLines.Count && IsTableLine(textLines[i + 1]))
-                    {
-                        i++;
-                        tableLines.Add(textLines[i]);
-                    }
-                    var formattedTable =
-                        FormatTableCommand.FormatTableString(string.Join(Environment.NewLine, tableLines));
-                    formattedTextLines.AddRange(formattedTable.Split(new[] { Environment.NewLine },
-                        StringSplitOptions.None));
-                }
-                else if (IsMultilineDelimeterLine(trimmedLine))
-                {
-                    formattedTextLines.AddRange(stringsToInsertBefore.Select(str => MultilineIndent + str));
-                    stringsToInsertBefore.Clear();
-
-                    formattedTextLines.Add(MultilineIndent + trimmedLine);
-
-                    //Find original indent of multiline argument
-                    int whitespaces = 0;
-                    while (char.IsWhiteSpace(textLines[i][whitespaces]))
-                    {
-                        whitespaces++;
-                    }
-                    string originalIndent = textLines[i].Substring(0, whitespaces);
-
-                    while (!IsMultilineDelimeterLine(textLines[++i]))
-                    {
-                        string formattedLine;
-                        if (textLines[i].StartsWith(originalIndent))
-                        {
-                            //replace original indent with MultilineIndent
-                            formattedLine = MultilineIndent + textLines[i].Substring(originalIndent.Length).TrimEnd();
-                        }
-                        else
-                        {
-                            //invalid case - leave it as it is
-                            formattedLine = textLines[i];
-                        }
-                        formattedTextLines.Add(formattedLine);
-                    }
-
-                    formattedTextLines.Add(MultilineIndent + textLines[i].Trim());
-                }
-                else if (IsBlockLine(trimmedLine, dialect) || IsStepLine(trimmedLine, dialect))
-                {
-                    if (_normalizeLineBreaks)
-                    {
-                        int addLinesBefore = GetPreceedingLineBreaks(trimmedLine, dialect);
-                        for (int j = 0; j < addLinesBefore; j++)
-                        {
-                            formattedTextLines.Add(string.Empty);
-                        }
-                    }
-                    string indent = GetIndent(trimmedLine, dialect);
-
-                    formattedTextLines.AddRange(stringsToInsertBefore.Select(str => indent + str));
-                    stringsToInsertBefore.Clear();
-
-                    formattedTextLines.Add(indent + trimmedLine);
-                }
-                else
-                {
-                    //Other lines - leave unchanged
-                    formattedTextLines.AddRange(stringsToInsertBefore);
-                    stringsToInsertBefore.Clear();
-
-                    formattedTextLines.Add(textLines[i]);
-                }
-            }
-
-            formattedTextLines.AddRange(stringsToInsertBefore);
-            stringsToInsertBefore.Clear();
-            return formattedTextLines;
-        }
-
-        private string GetIndent(string line, GherkinDialect dialect)
-        {
-            if (IsBlockLine(line, dialect))
-            {
-                var keyword = GetBlockKeyword(line, dialect);
-                switch (keyword)
-                {
-                    case GherkinBlockKeyword.Scenario:
-                    case GherkinBlockKeyword.ScenarioOutline:
-                    case GherkinBlockKeyword.Background:
-                        return ScenarioIndent;
-
-                    case GherkinBlockKeyword.Examples:
-                        return ExampleIndent;
-
-                    case GherkinBlockKeyword.Feature:
-                        return FeatureIndent;
-                }
-            }
-            else if (IsStepLine(line, dialect))
-            {
-                return GetConfiguredStepLineBreaksAndIndent();
-            }
-            else if (IsTableLine(line))
-            {
-                return TableIndent;
-            }
-
-            return string.Empty;
-        }
-
-        private string GetConfiguredStepLineBreaksAndIndent()
-        {
-            var str = string.Empty;
-
-            if (_normalizeLineBreaks)
-            {
-                for (var i = 0; i < _lineBreaksBeforeStep; i++)
-                {
-                    str = str + "\n";
-                }
-            }
-
-            return str + StepIndent;
-        }
-
-        private int GetPreceedingLineBreaks(string line, GherkinDialect dialect)
-        {
-            if (IsBlockLine(line, dialect))
-            {
-                var keyword = GetBlockKeyword(line, dialect);
-                switch (keyword)
-                {
-                    case GherkinBlockKeyword.Scenario:
-                    case GherkinBlockKeyword.ScenarioOutline:
-                    case GherkinBlockKeyword.Background:
-                        return _lineBreaksBeforeScenario;
-
-                    case GherkinBlockKeyword.Examples:
-                        return _lineBreaksBeforeExamples;
-
-                    case GherkinBlockKeyword.Feature:
-                        return _lineBreaksBeforeFeature;
-                }
-            }
-
-            return 0;
-        }
+		private bool _normalizeLineBreaks;
+		private int _lineBreaksBeforeStep;
+		private int _lineBreaksBeforeScenario;
+		private int _lineBreaksBeforeExamples;
+		private int _lineBreaksBeforeFeature;
 
 
-        private GherkinDialect GetDialect(GherkinLanguageService languageService)
-        {
-            var fileScope = languageService.GetFileScope(waitForResult: false);
-            return fileScope != null
-                ? fileScope.GherkinDialect
-                : languageService.ProjectScope.GherkinDialectServices.GetDefaultDialect();
-        }
+		public bool FormatDocument(GherkinEditorContext editorContext)
+		{
+			ConfigureLineBreakOptions(editorContext);
 
-        private bool IsBlockLine(string line, GherkinDialect dialect)
-        {
-            var trimmedLine = line.TrimStart();
-            return dialect.GetBlockKeywords().Any(keyword => trimmedLine.StartsWith(keyword));
-        }
+			var dialect = GetDialect(editorContext.LanguageService);
+			var textSnapshot = editorContext.TextView.TextSnapshot;
 
-        private GherkinBlockKeyword GetBlockKeyword(string line, GherkinDialect dialect)
-        {
-            var trimmedLine = line.TrimStart();
-            return Enum.GetValues(typeof(GherkinBlockKeyword))
-                .Cast<GherkinBlockKeyword>()
-                .First(keyword => dialect.GetBlockKeywords(keyword).Any(word => trimmedLine.StartsWith(word)));
-        }
+			var textLines = textSnapshot.Lines
+				.Select(line => line.GetText())
+				.ToList();
 
-        private bool IsStepLine(string line, GherkinDialect dialect)
-        {
-            var trimmedLine = line.TrimStart();
-            return dialect.GetStepKeywords().Any(keyword => trimmedLine.StartsWith(keyword));
-        }
+			var formattedTextLines = FormatText(textLines, dialect);
+			ReplaceText(textSnapshot, formattedTextLines);
 
-        private bool IsTableLine(string line)
-        {
-            return line.TrimStart().StartsWith(TableSeparator);
-        }
+			return true;
+		}
 
-        private bool IsCommentLine(string line)
-        {
-            return line.TrimStart().StartsWith(CommentSymbol);
-        }
+		private void ConfigureLineBreakOptions(GherkinEditorContext editorContext)
+		{
+			var options = editorContext.LanguageService.ProjectScope.IntegrationOptionsProvider.GetOptions();
+			_normalizeLineBreaks = options.NormalizeLineBreaks;
+			_lineBreaksBeforeStep = options.LineBreaksBeforeStep;
+			_lineBreaksBeforeScenario = options.LineBreaksBeforeScenario;
+			_lineBreaksBeforeExamples = options.LineBreaksBeforeExamples;
+			_lineBreaksBeforeFeature = options.LineBreaksBeforeFeature;
+		}
 
-        private bool IsTagLine(string line)
-        {
-            return line.TrimStart().StartsWith(TagSymbol);
-        }
+		private void ReplaceText(ITextSnapshot textSnapshot, List<string> newTextLines)
+		{
+			//Replacing text line-by-line preserves scroll and caret position
+			using (var edit = textSnapshot.TextBuffer.CreateEdit())
+			{
+				var currentLines = textSnapshot.Lines.ToList();
 
-        private bool IsMultilineDelimeterLine(string line)
-        {
-            return line.Trim() == MultilineArgumentDelimeter;
-        }
-    }
+				int k;
+				//Replace line-by-line
+				for (k = 0; k < currentLines.Count && k < newTextLines.Count; k++)
+				{
+					var line = currentLines[k];
+					if (line.GetText() != newTextLines[k])
+					{
+						var span = new SnapshotSpan(line.Start, line.End);
+						edit.Replace(span, newTextLines[k]);
+					}
+				}
+
+				//Replace anything left
+				var lastLine = currentLines[k - 1];
+				var endSpan = new SnapshotSpan(lastLine.End, currentLines.Last().EndIncludingLineBreak);
+				string remainingText = newTextLines.Count > k
+					? Environment.NewLine + string.Join(Environment.NewLine, newTextLines.Skip(k))
+					: string.Empty;
+				if (endSpan.GetText() != remainingText)
+				{
+					edit.Replace(endSpan, remainingText);
+				}
+
+				edit.Apply();
+			}
+		}
+
+		private List<string> FormatText(List<string> textLines, GherkinDialect dialect)
+		{
+			var formattedTextLines = new List<string>();
+
+			var stringsToInsertBefore = new List<string>();
+			for (int i = 0; i < textLines.Count; i++)
+			{
+				string trimmedLine = textLines[i].Trim();
+
+				if (string.IsNullOrWhiteSpace(textLines[i]))
+				{
+					if (!_normalizeLineBreaks)
+					{
+						formattedTextLines.AddRange(stringsToInsertBefore);
+						stringsToInsertBefore.Clear();
+						formattedTextLines.Add(string.Empty);
+					}
+				}
+				else if (IsCommentLine(trimmedLine) || IsTagLine(trimmedLine))
+				{
+					// Commment or tag lines should have same indent as following line,
+					// that's why we put them to temporary collection
+					stringsToInsertBefore.Add(trimmedLine);
+				}
+				else if (IsTableLine(trimmedLine))
+				{
+					formattedTextLines.AddRange(stringsToInsertBefore.Select(str => TableIndent + str));
+					stringsToInsertBefore.Clear();
+
+					//Find whole table, and format it using FormatTableCommand.FormatTableString
+					var tableLines = new List<string>();
+					tableLines.Add(TableIndent + trimmedLine);
+					while (i + 1 < textLines.Count && IsTableLine(textLines[i + 1]))
+					{
+						i++;
+						tableLines.Add(textLines[i]);
+					}
+					var formattedTable =
+						FormatTableCommand.FormatTableString(string.Join(Environment.NewLine, tableLines));
+					formattedTextLines.AddRange(formattedTable.Split(new[] { Environment.NewLine },
+						StringSplitOptions.None));
+				}
+				else if (IsMultilineDelimeterLine(trimmedLine))
+				{
+					formattedTextLines.AddRange(stringsToInsertBefore.Select(str => MultilineIndent + str));
+					stringsToInsertBefore.Clear();
+
+					formattedTextLines.Add(MultilineIndent + trimmedLine);
+
+					//Find original indent of multiline argument
+					int whitespaces = 0;
+					while (char.IsWhiteSpace(textLines[i][whitespaces]))
+					{
+						whitespaces++;
+					}
+					string originalIndent = textLines[i].Substring(0, whitespaces);
+
+					while (!IsMultilineDelimeterLine(textLines[++i]))
+					{
+						string formattedLine;
+						if (textLines[i].StartsWith(originalIndent))
+						{
+							//replace original indent with MultilineIndent
+							formattedLine = MultilineIndent + textLines[i].Substring(originalIndent.Length).TrimEnd();
+						}
+						else
+						{
+							//invalid case - leave it as it is
+							formattedLine = textLines[i];
+						}
+						formattedTextLines.Add(formattedLine);
+					}
+
+					formattedTextLines.Add(MultilineIndent + textLines[i].Trim());
+				}
+				else if (IsBlockLine(trimmedLine, dialect) || IsStepLine(trimmedLine, dialect))
+				{
+					if (_normalizeLineBreaks)
+					{
+						int addLinesBefore = GetPreceedingLineBreaks(trimmedLine, dialect);
+						for (int j = 0; j < addLinesBefore; j++)
+						{
+							formattedTextLines.Add(string.Empty);
+						}
+					}
+					string indent = GetIndent(trimmedLine, dialect);
+
+					formattedTextLines.AddRange(stringsToInsertBefore.Select(str => indent + str));
+					stringsToInsertBefore.Clear();
+
+					formattedTextLines.Add(indent + trimmedLine);
+				}
+				else
+				{
+					//Other lines - leave unchanged
+					formattedTextLines.AddRange(stringsToInsertBefore);
+					stringsToInsertBefore.Clear();
+
+					formattedTextLines.Add(textLines[i]);
+				}
+			}
+
+			formattedTextLines.AddRange(stringsToInsertBefore);
+			stringsToInsertBefore.Clear();
+			return formattedTextLines;
+		}
+
+		private string GetIndent(string line, GherkinDialect dialect)
+		{
+			if (IsBlockLine(line, dialect))
+			{
+				var keyword = GetBlockKeyword(line, dialect);
+				switch (keyword)
+				{
+					case GherkinBlockKeyword.Scenario:
+					case GherkinBlockKeyword.ScenarioOutline:
+					case GherkinBlockKeyword.Background:
+						return ScenarioIndent;
+
+					case GherkinBlockKeyword.Examples:
+						return ExampleIndent;
+
+					case GherkinBlockKeyword.Feature:
+						return FeatureIndent;
+				}
+			}
+			else if (IsStepLine(line, dialect))
+			{
+				return GetConfiguredStepLineBreaksAndIndent();
+			}
+			else if (IsTableLine(line))
+			{
+				return TableIndent;
+			}
+
+			return string.Empty;
+		}
+
+		private string GetConfiguredStepLineBreaksAndIndent()
+		{
+			var str = string.Empty;
+
+			if (_normalizeLineBreaks)
+			{
+				for (var i = 0; i < _lineBreaksBeforeStep; i++)
+				{
+					str = str + Environment.NewLine;
+				}
+			}
+
+			return str + StepIndent;
+		}
+
+		private int GetPreceedingLineBreaks(string line, GherkinDialect dialect)
+		{
+			if (IsBlockLine(line, dialect))
+			{
+				var keyword = GetBlockKeyword(line, dialect);
+				switch (keyword)
+				{
+					case GherkinBlockKeyword.Scenario:
+					case GherkinBlockKeyword.ScenarioOutline:
+					case GherkinBlockKeyword.Background:
+						return _lineBreaksBeforeScenario;
+
+					case GherkinBlockKeyword.Examples:
+						return _lineBreaksBeforeExamples;
+
+					case GherkinBlockKeyword.Feature:
+						return _lineBreaksBeforeFeature;
+				}
+			}
+
+			return 0;
+		}
+
+
+		private GherkinDialect GetDialect(GherkinLanguageService languageService)
+		{
+			var fileScope = languageService.GetFileScope(waitForResult: false);
+			return fileScope != null
+				? fileScope.GherkinDialect
+				: languageService.ProjectScope.GherkinDialectServices.GetDefaultDialect();
+		}
+
+		private bool IsBlockLine(string line, GherkinDialect dialect)
+		{
+			var trimmedLine = line.TrimStart();
+			return dialect.GetBlockKeywords().Any(keyword => trimmedLine.StartsWith(keyword));
+		}
+
+		private GherkinBlockKeyword GetBlockKeyword(string line, GherkinDialect dialect)
+		{
+			var trimmedLine = line.TrimStart();
+			return Enum.GetValues(typeof(GherkinBlockKeyword))
+				.Cast<GherkinBlockKeyword>()
+				.First(keyword => dialect.GetBlockKeywords(keyword).Any(word => trimmedLine.StartsWith(word)));
+		}
+
+		private bool IsStepLine(string line, GherkinDialect dialect)
+		{
+			var trimmedLine = line.TrimStart();
+			return dialect.GetStepKeywords().Any(keyword => trimmedLine.StartsWith(keyword));
+		}
+
+		private bool IsTableLine(string line)
+		{
+			return line.TrimStart().StartsWith(TableSeparator);
+		}
+
+		private bool IsCommentLine(string line)
+		{
+			return line.TrimStart().StartsWith(CommentSymbol);
+		}
+
+		private bool IsTagLine(string line)
+		{
+			return line.TrimStart().StartsWith(TagSymbol);
+		}
+
+		private bool IsMultilineDelimeterLine(string line)
+		{
+			return line.Trim() == MultilineArgumentDelimeter;
+		}
+	}
 }

--- a/VsIntegration/EditorCommands/FormatDocumentCommand.cs
+++ b/VsIntegration/EditorCommands/FormatDocumentCommand.cs
@@ -1,0 +1,290 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.Text;
+using TechTalk.SpecFlow.Parser;
+using TechTalk.SpecFlow.VsIntegration.LanguageService;
+
+namespace TechTalk.SpecFlow.VsIntegration.EditorCommands
+{
+    internal class FormatDocumentCommand
+    {
+        private const string FeatureIndent = "";
+        private const string ScenarioIndent = "";
+        private const string StepIndent = "\t";
+        private const string TableIndent = "\t\t";
+        private const string MultilineIndent = "\t\t";
+        private const string ExampleIndent = "\t";
+
+        private const int LineBreaksBeforeScenario = 1;
+        private const int LineBreaksBeforeExamples = 1;
+        private const int LineBreaksBeforeFeature = 0;
+
+        private const bool NormalizeLineBreaks = true;
+
+        private const string CommentSymbol = "#";
+        private const string TableSeparator = "|";
+        private const string TagSymbol = "@";
+        private const string MultilineArgumentDelimeter = "\"\"\"";
+
+
+        public bool FormatDocument(GherkinEditorContext editorContext)
+        {
+            var dialect = GetDialect(editorContext.LanguageService);
+            var textSnapshot = editorContext.TextView.TextSnapshot;
+
+            var textLines = textSnapshot.Lines
+                .Select(line => line.GetText())
+                .ToList();
+
+            var formattedTextLines = FormatText(textLines, dialect);
+            ReplaceText(textSnapshot, formattedTextLines);
+
+            return true;
+        }
+
+        private void ReplaceText(ITextSnapshot textSnapshot, List<string> newTextLines)
+        {
+            //Replacing text line-by-line preserves scroll and caret position
+            using (var edit = textSnapshot.TextBuffer.CreateEdit())
+            {
+                var currentLines = textSnapshot.Lines.ToList();
+
+                int k;
+                //Replace line-by-line
+                for (k = 0; k < currentLines.Count && k < newTextLines.Count; k++)
+                {
+                    var line = currentLines[k];
+                    if (line.GetText() != newTextLines[k])
+                    {
+                        var span = new SnapshotSpan(line.Start, line.End);
+                        edit.Replace(span, newTextLines[k]);
+                    }
+                }
+
+                //Replace anything left
+                var lastLine = currentLines[k - 1];
+                var endSpan = new SnapshotSpan(lastLine.End, currentLines.Last().EndIncludingLineBreak);
+                string remainingText = newTextLines.Count > k
+                    ? Environment.NewLine + string.Join(Environment.NewLine, newTextLines.Skip(k))
+                    : string.Empty;
+                if (endSpan.GetText() != remainingText)
+                {
+                    edit.Replace(endSpan, remainingText);
+                }
+
+                edit.Apply();
+            }
+        }
+
+        private List<string> FormatText(List<string> textLines, GherkinDialect dialect)
+        {
+            var formattedTextLines = new List<string>();
+
+            var stringsToInsertBefore = new List<string>();
+            for (int i = 0; i < textLines.Count; i++)
+            {
+                string trimmedLine = textLines[i].Trim();
+
+                if (string.IsNullOrWhiteSpace(textLines[i]))
+                {
+                    if (!NormalizeLineBreaks)
+                    {
+                        formattedTextLines.AddRange(stringsToInsertBefore);
+                        stringsToInsertBefore.Clear();
+                        formattedTextLines.Add(string.Empty);
+                    }
+                }
+                else if (IsCommentLine(trimmedLine) || IsTagLine(trimmedLine))
+                {
+                    // Commment or tag lines should have same indent as following line,
+                    // that's why we put them to temporary collection
+                    stringsToInsertBefore.Add(trimmedLine);
+                }
+                else if (IsTableLine(trimmedLine))
+                {
+                    formattedTextLines.AddRange(stringsToInsertBefore.Select(str => TableIndent + str));
+                    stringsToInsertBefore.Clear();
+
+                    //Find whole table, and format it using FormatTableCommand.FormatTableString
+                    var tableLines = new List<string>();
+                    tableLines.Add(TableIndent + trimmedLine);
+                    while (i + 1 < textLines.Count && IsTableLine(textLines[i + 1]))
+                    {
+                        i++;
+                        tableLines.Add(textLines[i]);
+                    }
+                    var formattedTable =
+                        FormatTableCommand.FormatTableString(string.Join(Environment.NewLine, tableLines));
+                    formattedTextLines.AddRange(formattedTable.Split(new[] { Environment.NewLine },
+                        StringSplitOptions.None));
+                }
+                else if (IsMultilineDelimeterLine(trimmedLine))
+                {
+                    formattedTextLines.AddRange(stringsToInsertBefore.Select(str => MultilineIndent + str));
+                    stringsToInsertBefore.Clear();
+
+                    formattedTextLines.Add(MultilineIndent + trimmedLine);
+
+                    //Find original indent of multiline argument
+                    int whitespaces = 0;
+                    while (char.IsWhiteSpace(textLines[i][whitespaces]))
+                    {
+                        whitespaces++;
+                    }
+                    string originalIndent = textLines[i].Substring(0, whitespaces);
+
+                    while (!IsMultilineDelimeterLine(textLines[++i]))
+                    {
+                        string formattedLine;
+                        if (textLines[i].StartsWith(originalIndent))
+                        {
+                            //replace original indent with MultilineIndent
+                            formattedLine = MultilineIndent + textLines[i].Substring(originalIndent.Length).TrimEnd();
+                        }
+                        else
+                        {
+                            //invalid case - leave it as it is
+                            formattedLine = textLines[i];
+                        }
+                        formattedTextLines.Add(formattedLine);
+                    }
+
+                    formattedTextLines.Add(MultilineIndent + textLines[i].Trim());
+                }
+                else if (IsBlockLine(trimmedLine, dialect) || IsStepLine(trimmedLine, dialect))
+                {
+                    if (NormalizeLineBreaks)
+                    {
+                        int addLinesBefore = GetPreceedingLineBreaks(trimmedLine, dialect);
+                        for (int j = 0; j < addLinesBefore; j++)
+                        {
+                            formattedTextLines.Add(string.Empty);
+                        }
+                    }
+                    string indent = GetIndent(trimmedLine, dialect);
+
+                    formattedTextLines.AddRange(stringsToInsertBefore.Select(str => indent + str));
+                    stringsToInsertBefore.Clear();
+
+                    formattedTextLines.Add(indent + trimmedLine);
+                }
+                else
+                {
+                    //Other lines - leave unchanged
+                    formattedTextLines.AddRange(stringsToInsertBefore);
+                    stringsToInsertBefore.Clear();
+
+                    formattedTextLines.Add(textLines[i]);
+                }
+            }
+
+            formattedTextLines.AddRange(stringsToInsertBefore);
+            stringsToInsertBefore.Clear();
+            return formattedTextLines;
+        }
+
+        private string GetIndent(string line, GherkinDialect dialect)
+        {
+            if (IsBlockLine(line, dialect))
+            {
+                var keyword = GetBlockKeyword(line, dialect);
+                switch (keyword)
+                {
+                    case GherkinBlockKeyword.Scenario:
+                    case GherkinBlockKeyword.ScenarioOutline:
+                    case GherkinBlockKeyword.Background:
+                        return ScenarioIndent;
+
+                    case GherkinBlockKeyword.Examples:
+                        return ExampleIndent;
+
+                    case GherkinBlockKeyword.Feature:
+                        return FeatureIndent;
+                }
+            }
+            else if (IsStepLine(line, dialect))
+            {
+                return StepIndent;
+            }
+            else if (IsTableLine(line))
+            {
+                return TableIndent;
+            }
+
+            return string.Empty;
+        }
+
+        private int GetPreceedingLineBreaks(string line, GherkinDialect dialect)
+        {
+            if (IsBlockLine(line, dialect))
+            {
+                var keyword = GetBlockKeyword(line, dialect);
+                switch (keyword)
+                {
+                    case GherkinBlockKeyword.Scenario:
+                    case GherkinBlockKeyword.ScenarioOutline:
+                    case GherkinBlockKeyword.Background:
+                        return LineBreaksBeforeScenario;
+
+                    case GherkinBlockKeyword.Examples:
+                        return LineBreaksBeforeExamples;
+
+                    case GherkinBlockKeyword.Feature:
+                        return LineBreaksBeforeFeature;
+                }
+            }
+
+            return 0;
+        }
+
+
+        private GherkinDialect GetDialect(GherkinLanguageService languageService)
+        {
+            var fileScope = languageService.GetFileScope(waitForResult: false);
+            return fileScope != null
+                ? fileScope.GherkinDialect
+                : languageService.ProjectScope.GherkinDialectServices.GetDefaultDialect();
+        }
+
+        private bool IsBlockLine(string line, GherkinDialect dialect)
+        {
+            var trimmedLine = line.TrimStart();
+            return dialect.GetBlockKeywords().Any(keyword => trimmedLine.StartsWith(keyword));
+        }
+
+        private GherkinBlockKeyword GetBlockKeyword(string line, GherkinDialect dialect)
+        {
+            var trimmedLine = line.TrimStart();
+            return Enum.GetValues(typeof(GherkinBlockKeyword))
+                .Cast<GherkinBlockKeyword>()
+                .First(keyword => dialect.GetBlockKeywords(keyword).Any(word => trimmedLine.StartsWith(word)));
+        }
+
+        private bool IsStepLine(string line, GherkinDialect dialect)
+        {
+            var trimmedLine = line.TrimStart();
+            return dialect.GetStepKeywords().Any(keyword => trimmedLine.StartsWith(keyword));
+        }
+
+        private bool IsTableLine(string line)
+        {
+            return line.TrimStart().StartsWith(TableSeparator);
+        }
+
+        private bool IsCommentLine(string line)
+        {
+            return line.TrimStart().StartsWith(CommentSymbol);
+        }
+
+        private bool IsTagLine(string line)
+        {
+            return line.TrimStart().StartsWith(TagSymbol);
+        }
+
+        private bool IsMultilineDelimeterLine(string line)
+        {
+            return line.Trim() == MultilineArgumentDelimeter;
+        }
+    }
+}

--- a/VsIntegration/EditorCommands/FormatTableCommand.cs
+++ b/VsIntegration/EditorCommands/FormatTableCommand.cs
@@ -53,7 +53,7 @@ namespace TechTalk.SpecFlow.VsIntegration.EditorCommands
             return trimmedLine.StartsWith("|");
         }
 
-        private string FormatTableString(string oldTable)
+        internal static string FormatTableString(string oldTable)
         {
             const string escapedPipeString = "\\\0";
             oldTable = oldTable.Replace("\\|", escapedPipeString);
@@ -114,7 +114,7 @@ namespace TechTalk.SpecFlow.VsIntegration.EditorCommands
             return stringBuilder.ToString().Replace(escapedPipeString, "\\|");
         }
 
-        private string[] GetCells(string line)
+        private static string[] GetCells(string line)
         {
             line = line.Trim();
             if (line.StartsWith("|"))

--- a/VsIntegration/Options/IntegrationOptionsProvider.cs
+++ b/VsIntegration/Options/IntegrationOptionsProvider.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.ComponentModel.Composition;
-using System.Linq;
+﻿using System.ComponentModel.Composition;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using TechTalk.SpecFlow.IdeIntegration.Options;
@@ -27,6 +25,11 @@ namespace TechTalk.SpecFlow.VsIntegration.Options
         public const TestRunnerTool TestRunnerToolDefaultValue = TestRunnerTool.Auto;
         public const bool DisableRegenerateFeatureFilePopupOnConfigChangeDefaultValue = false;
         public const GenerationMode GenerationModeDefaultValue = GenerationMode.OutOfProcess;
+        public const bool NormalizeLineBreaksDefaultValue = true;
+        public const int LineBreaksBeforeStepDefaultValue = 1;
+        public const int LineBreaksBeforeScenarioDefaultValue = 1;
+        public const int LineBreaksBeforeExamplesDefaultValue = 1;
+        public const int LineBreaksBeforeFeatureDefaultValue = 0;
 
         private DTE dte;
 
@@ -51,19 +54,24 @@ namespace TechTalk.SpecFlow.VsIntegration.Options
                 return options;
 
             options = new IntegrationOptions
-                                          {
-                                              EnableSyntaxColoring = GetGeneralOption(dte, "EnableSyntaxColoring", EnableSyntaxColoringDefaultValue),
-                                              EnableOutlining = GetGeneralOption(dte, "EnableOutlining", EnableOutliningDefaultValue),
-                                              EnableIntelliSense = GetGeneralOption(dte, "EnableIntelliSense", EnableIntelliSenseDefaultValue),
-                                              EnableAnalysis = GetGeneralOption(dte, "EnableAnalysis", EnableAnalysisDefaultValue),
-                                              EnableTableAutoFormat = GetGeneralOption(dte, "EnableTableAutoFormat", EnableTableAutoFormatDefaultValue),
-                                              EnableStepMatchColoring = GetGeneralOption(dte, "EnableStepMatchColoring", EnableStepMatchColoringDefaultValue),
-                                              EnableTracing = GetGeneralOption(dte, "EnableTracing", EnableTracingDefaultValue),
-                                              TracingCategories = GetGeneralOption(dte, "TracingCategories", TracingCategoriesDefaultValue),
-                                              TestRunnerTool = GetGeneralOption(dte, "TestRunnerTool", TestRunnerToolDefaultValue),
-                                              DisableRegenerateFeatureFilePopupOnConfigChange = GetGeneralOption(dte, "DisableRegenerateFeatureFilePopupOnConfigChange", DisableRegenerateFeatureFilePopupOnConfigChangeDefaultValue),
-                                              GenerationMode = GetGeneralOption(dte, "GenerationMode", GenerationModeDefaultValue)
-                                          };
+            {
+                EnableSyntaxColoring = GetGeneralOption(dte, "EnableSyntaxColoring", EnableSyntaxColoringDefaultValue),
+                EnableOutlining = GetGeneralOption(dte, "EnableOutlining", EnableOutliningDefaultValue),
+                EnableIntelliSense = GetGeneralOption(dte, "EnableIntelliSense", EnableIntelliSenseDefaultValue),
+                EnableAnalysis = GetGeneralOption(dte, "EnableAnalysis", EnableAnalysisDefaultValue),
+                EnableTableAutoFormat = GetGeneralOption(dte, "EnableTableAutoFormat", EnableTableAutoFormatDefaultValue),
+                EnableStepMatchColoring = GetGeneralOption(dte, "EnableStepMatchColoring", EnableStepMatchColoringDefaultValue),
+                EnableTracing = GetGeneralOption(dte, "EnableTracing", EnableTracingDefaultValue),
+                TracingCategories = GetGeneralOption(dte, "TracingCategories", TracingCategoriesDefaultValue),
+                TestRunnerTool = GetGeneralOption(dte, "TestRunnerTool", TestRunnerToolDefaultValue),
+                DisableRegenerateFeatureFilePopupOnConfigChange = GetGeneralOption(dte, "DisableRegenerateFeatureFilePopupOnConfigChange", DisableRegenerateFeatureFilePopupOnConfigChangeDefaultValue),
+                GenerationMode = GetGeneralOption(dte, "GenerationMode", GenerationModeDefaultValue),
+                NormalizeLineBreaks = GetGeneralOption(dte, "NormalizeLineBreaks", NormalizeLineBreaksDefaultValue),
+                LineBreaksBeforeStep = GetGeneralOption(dte, "LineBreaksBeforeStep", LineBreaksBeforeStepDefaultValue),
+                LineBreaksBeforeFeature = GetGeneralOption(dte, "LineBreaksBeforeFeature", LineBreaksBeforeFeatureDefaultValue),
+                LineBreaksBeforeExamples = GetGeneralOption(dte, "LineBreaksBeforeExamples", LineBreaksBeforeExamplesDefaultValue),
+                LineBreaksBeforeScenario = GetGeneralOption(dte, "LineBreaksBeforeScenario", LineBreaksBeforeScenarioDefaultValue)
+            };
             cachedOptions = options;
             return options;
         }

--- a/VsIntegration/Options/OptionsPageGeneral.cs
+++ b/VsIntegration/Options/OptionsPageGeneral.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell;
@@ -96,6 +95,36 @@ namespace TechTalk.SpecFlow.VsIntegration.Options
         [DefaultValue(IntegrationOptionsProvider.GenerationModeDefaultValue)]
         public GenerationMode GenerationMode { get; set; }
 
+        [Category("Feature File Formatting")]
+        [Description("Specifies if line breaks will be normalized when the format document command is executed. If set to false, all configurations in the Feature File Formatting section will not take any effect.")]
+        [DisplayName("Normalize line breaks")]
+        [DefaultValue(IntegrationOptionsProvider.NormalizeLineBreaksDefaultValue)]
+        public bool NormalizeLineBreaks { get; set; }
+
+        [Category("Feature File Formatting")]
+        [Description("Specifies the number of line breaks which will be placed before a step definition when the format document command is executed.")]
+        [DisplayName("Line breaks before step definitions")]
+        [DefaultValue(IntegrationOptionsProvider.LineBreaksBeforeStepDefaultValue)]
+        public int LineBreaksBeforeStep { get; set; }
+
+        [Category("Feature File Formatting")]
+        [Description("Specifies the number of line breaks which will be placed before a scenario definition when the format document command is executed.")]
+        [DisplayName("Line breaks before scenario definitions")]
+        [DefaultValue(IntegrationOptionsProvider.LineBreaksBeforeScenarioDefaultValue)]
+        public int LineBreaksBeforeScenario { get; set; }
+
+        [Category("Feature File Formatting")]
+        [Description("Specifies the number of line breaks which will be placed before example definitions when the format document command is executed.")]
+        [DisplayName("Line breaks before example definitions")]
+        [DefaultValue(IntegrationOptionsProvider.LineBreaksBeforeExamplesDefaultValue)]
+        public int LineBreaksBeforeExamples { get; set; }
+
+        [Category("Feature File Formatting")]
+        [Description("Specifies the number of line breaks which will be placed before a feature definition when the format document command is executed.")]
+        [DisplayName("Line breaks before feature definitions")]
+        [DefaultValue(IntegrationOptionsProvider.LineBreaksBeforeFeatureDefaultValue)]
+        public int LineBreaksBeforeFeature { get; set; }
+
         public OptionsPageGeneral()
         {
             EnableAnalysis = IntegrationOptionsProvider.EnableAnalysisDefaultValue;
@@ -109,6 +138,12 @@ namespace TechTalk.SpecFlow.VsIntegration.Options
             TestRunnerTool = IntegrationOptionsProvider.TestRunnerToolDefaultValue;
             DisableRegenerateFeatureFilePopupOnConfigChange = IntegrationOptionsProvider.DisableRegenerateFeatureFilePopupOnConfigChangeDefaultValue;
             GenerationMode = IntegrationOptionsProvider.GenerationModeDefaultValue;
+
+            NormalizeLineBreaks = IntegrationOptionsProvider.NormalizeLineBreaksDefaultValue;
+            LineBreaksBeforeStep = IntegrationOptionsProvider.LineBreaksBeforeStepDefaultValue;
+            LineBreaksBeforeScenario = IntegrationOptionsProvider.LineBreaksBeforeScenarioDefaultValue;
+            LineBreaksBeforeExamples = IntegrationOptionsProvider.LineBreaksBeforeExamplesDefaultValue;
+            LineBreaksBeforeFeature = IntegrationOptionsProvider.LineBreaksBeforeFeatureDefaultValue;
         }
 
         public override void SaveSettingsToStorage()

--- a/VsIntegration/TechTalk.SpecFlow.VsIntegration.2013.csproj
+++ b/VsIntegration/TechTalk.SpecFlow.VsIntegration.2013.csproj
@@ -229,6 +229,7 @@
     <Compile Include="Commands\SpecFlowProjectSingleSelectionCommand.cs" />
     <Compile Include="EditorCommands\CommentUncommentCommand.cs" />
     <Compile Include="EditorCommands\EditorCommandFilter.cs" />
+    <Compile Include="EditorCommands\FormatDocumentCommand.cs" />
     <Compile Include="EditorCommands\FormatTableCommand.cs" />
     <Compile Include="EditorCommands\GherkinEditorContext.cs" />
     <Compile Include="EditorCommands\GherkinTextViewCreationListener.cs" />

--- a/VsIntegration/TechTalk.SpecFlow.VsIntegration.2015.csproj
+++ b/VsIntegration/TechTalk.SpecFlow.VsIntegration.2015.csproj
@@ -229,6 +229,7 @@
     <Compile Include="Commands\SpecFlowProjectSingleSelectionCommand.cs" />
     <Compile Include="EditorCommands\CommentUncommentCommand.cs" />
     <Compile Include="EditorCommands\EditorCommandFilter.cs" />
+    <Compile Include="EditorCommands\FormatDocumentCommand.cs" />
     <Compile Include="EditorCommands\FormatTableCommand.cs" />
     <Compile Include="EditorCommands\GherkinEditorContext.cs" />
     <Compile Include="EditorCommands\GherkinTextViewCreationListener.cs" />

--- a/VsIntegration/TechTalk.SpecFlow.VsIntegration.2017.csproj
+++ b/VsIntegration/TechTalk.SpecFlow.VsIntegration.2017.csproj
@@ -229,6 +229,7 @@
     <Compile Include="Commands\SpecFlowProjectSingleSelectionCommand.cs" />
     <Compile Include="EditorCommands\CommentUncommentCommand.cs" />
     <Compile Include="EditorCommands\EditorCommandFilter.cs" />
+    <Compile Include="EditorCommands\FormatDocumentCommand.cs" />
     <Compile Include="EditorCommands\FormatTableCommand.cs" />
     <Compile Include="EditorCommands\GherkinEditorContext.cs" />
     <Compile Include="EditorCommands\GherkinTextViewCreationListener.cs" />

--- a/VsIntegration/TechTalk.SpecFlow.VsIntegration.csproj
+++ b/VsIntegration/TechTalk.SpecFlow.VsIntegration.csproj
@@ -225,6 +225,7 @@
     <Compile Include="Commands\SpecFlowProjectSingleSelectionCommand.cs" />
     <Compile Include="EditorCommands\CommentUncommentCommand.cs" />
     <Compile Include="EditorCommands\EditorCommandFilter.cs" />
+    <Compile Include="EditorCommands\FormatDocumentCommand.cs" />
     <Compile Include="EditorCommands\FormatTableCommand.cs" />
     <Compile Include="EditorCommands\GherkinEditorContext.cs" />
     <Compile Include="EditorCommands\GherkinTextViewCreationListener.cs" />


### PR DESCRIPTION
Original PR from @Dreamescaper with #18.

Add basic FormatDocument command (Edit > Advanced > Format Document) support to gherkin editor.
It does the following:

- normalize indents
- normalize line breaks
- format all tables

I further improved the code from @Dreamescaper by adding configurable Visual Studio settings for different options.

This version was tested at work for an entire week. The basic functionality is working. The following known issues and improvements should be or can be tackled before merging:

- [ ] Tabs vs. Spaces for indention. It is not possible to read the Visual Studio settings. Therefore we provide a configuration on our on.
- [ ] If there is a table definition only with header definitions (no body rows) the format document command crashes.
- [ ] The cursor position is not (always) preserved when executing the format document command. This results in a "jumping" cursor. **Help appreciated**

**Question:** I recognized that some of our developers indent 'And' steps following 'Given' or 'Then' steps and other place them on the same vertical position. Should this be a configurable option as well?

@SabotageAndi any feedback would be helpful and highly appreciated. I will keep on working on this feature until it can be merged into master.