### PR TITLE
Issue 1234

### DIFF
--- a/IdeIntegration/Generator/OutOfProcess/OutOfProcessExecutor.cs
+++ b/IdeIntegration/Generator/OutOfProcess/OutOfProcessExecutor.cs
@@ -34,7 +34,10 @@ namespace TechTalk.SpecFlow.IdeIntegration.Generator.OutOfProcess
 
         public Result Execute(CommonParameters commonParameters, bool transferViaFile)
         {
-            commonParameters.OutputDirectory = String.IsNullOrWhiteSpace(_integrationOptions.CodeBehindFileGeneratorExchangePath) ? Path.GetTempPath() : _integrationOptions.CodeBehindFileGeneratorExchangePath;
+            commonParameters.OutputDirectory =
+                String.IsNullOrWhiteSpace(_integrationOptions.CodeBehindFileGeneratorExchangePath)
+                    ? Path.GetDirectoryName(Path.GetTempPath())
+                    : _integrationOptions.CodeBehindFileGeneratorExchangePath;
 
 
             string commandLineParameters = CommandLine.Parser.Default.FormatCommandLine(commonParameters);


### PR DESCRIPTION
The issue is actually '1234' / not lazy-typing: https://github.com/techtalk/SpecFlow/issues/1234
The temp file path will end in a backslash, which causes the command line generator to improperly quote the output directory. 
--
Confirmed / fixed the issue with code behind files failing to generate. 
The issue was that the Path.GetTempPath() call returns a string ending in a backslash. This doesn't bode well in the subsequent call to the CommandLineParser when it generates the command line parameters for the call to the *.CodeBehindGenerator.exe
