### PR TITLE
Step coloring fixes

### DIFF
--- a/VsIntegration/LanguageService/GherkinTextBufferParserListener.cs
+++ b/VsIntegration/LanguageService/GherkinTextBufferParserListener.cs
@@ -359,10 +359,23 @@ namespace TechTalk.SpecFlow.VsIntegration.LanguageService
                 if (match.Success)
                 {
                     ColorizeKeywordLine(keyword, stepSpan, classifications.StepText);
-                    int linePos = stepSpan.StartPosition.LinePosition;
-                    foreach (var stringArg in match.Arguments.OfType<string>())
+
+                    var regexMatch = match.StepBinding.Regex.Match(text);
+                    if (regexMatch.Success)
                     {
-                        linePos = ColorizeLinePart(stringArg, stepSpan, classifications.StepArgument, linePos);
+                        var textStart = KeywordAndWhitespaceLength(keyword, stepSpan, editorLine);
+                        foreach (Group matchGroup in regexMatch.Groups.Cast<Group>().Skip(1))
+                        {
+                            var captures = matchGroup.Captures;
+                            var lastCapture = captures[captures.Count - 1];
+                            var partStart = textStart + captures[0].Index;
+                            var partEnd = textStart + lastCapture.Index + lastCapture.Length;
+                            ColorizeLinePart(partStart, partEnd, stepSpan, classifications.StepArgument);
+                        }
+                    }
+                    else
+                    {
+                        // this should never happen
                     }
                 }
                 else if (CurrentFileBlockBuilder.BlockType == typeof(IScenarioOutlineBlock) && placeholderRe.Match(text).Success)

--- a/VsIntegration/LanguageService/GherkinTextBufferParserListener.cs
+++ b/VsIntegration/LanguageService/GherkinTextBufferParserListener.cs
@@ -56,7 +56,7 @@ namespace TechTalk.SpecFlow.VsIntegration.LanguageService
             this.classifications = projectScope.Classifications;
             this.projectScope = projectScope;
             this.enableStepMatchColoring = projectScope.IntegrationOptionsProvider.GetOptions().EnableStepMatchColoring;
-           
+
             gherkinFileScope = new GherkinFileScope(gherkinDialect, textSnapshot);
         }
 
@@ -90,10 +90,10 @@ namespace TechTalk.SpecFlow.VsIntegration.LanguageService
                 return;
 
             var startLine = textSnapshot.GetLineFromLineNumber(span.StartPosition.Line);
-            var endLine = span.StartPosition.Line == span.EndPosition.Line ? 
+            var endLine = span.StartPosition.Line == span.EndPosition.Line ?
                 startLine : textSnapshot.GetLineFromLineNumber(span.EndPosition.Line);
             var startIndex = startLine.Start + span.StartPosition.LinePosition;
-            var endLinePosition = span.EndPosition.LinePosition == endLine.Length ? 
+            var endLinePosition = span.EndPosition.LinePosition == endLine.Length ?
                 endLine.LengthIncludingLineBreak : span.EndPosition.LinePosition;
             var length = endLine.Start + endLinePosition - startIndex;
             AddClassification(classificationType, startIndex, length);
@@ -278,7 +278,7 @@ namespace TechTalk.SpecFlow.VsIntegration.LanguageService
             RegisterKeyword(keyword, headerSpan);
             ColorizeSpan(descriptionSpan, classifications.Description);
 
-            ScenarioOutlineExampleSet exampleSet = new ScenarioOutlineExampleSet(keyword, name, 
+            ScenarioOutlineExampleSet exampleSet = new ScenarioOutlineExampleSet(keyword, name,
                 editorLine - CurrentFileBlockBuilder.KeywordLine);
             CurrentFileBlockBuilder.ExampleSets.Add(exampleSet);
             currentStep = null;

--- a/VsIntegration/LanguageService/GherkinTextBufferParserListener.cs
+++ b/VsIntegration/LanguageService/GherkinTextBufferParserListener.cs
@@ -381,8 +381,13 @@ namespace TechTalk.SpecFlow.VsIntegration.LanguageService
             if (CurrentFileBlockBuilder.BlockType == typeof(IScenarioOutlineBlock))
             {
                 var matches = placeholderRe.Matches(text);
+                var textStart = KeywordAndWhitespaceLength(keyword, stepSpan, editorLine);
                 foreach (Match match in matches)
-                    ColorizeLinePart(match.Value, stepSpan, classifications.Placeholder);
+                {
+                    var capture = match.Groups[0].Captures[0];
+                    var start = textStart + capture.Index;
+                    ColorizeLinePart(start, start + capture.Length, stepSpan, classifications.Placeholder);
+                }
             }
         }
 

--- a/VsIntegration/LanguageService/GherkinTextBufferParserListener.cs
+++ b/VsIntegration/LanguageService/GherkinTextBufferParserListener.cs
@@ -386,6 +386,16 @@ namespace TechTalk.SpecFlow.VsIntegration.LanguageService
             }
         }
 
+        private static int KeywordAndWhitespaceLength(string keyword, GherkinBufferSpan stepSpan, int editorLine)
+        {
+            var content = stepSpan.Buffer.GetContentFrom(editorLine);
+            var indentLength = content.TakeWhile(Char.IsWhiteSpace).Count();
+            return
+                indentLength
+                + keyword.Length
+                + content.Skip(indentLength + keyword.Length).TakeWhile(Char.IsWhiteSpace).Count();
+        }
+
         public void TableHeader(string[] cells, GherkinBufferSpan rowSpan, GherkinBufferSpan[] cellSpans)
         {
             foreach (var cellSpan in cellSpans)

--- a/VsIntegration/LanguageService/GherkinTextBufferParserListener.cs
+++ b/VsIntegration/LanguageService/GherkinTextBufferParserListener.cs
@@ -112,6 +112,13 @@ namespace TechTalk.SpecFlow.VsIntegration.LanguageService
             return textPosition.LinePosition + value.Length;
         }
 
+        private int ColorizeLinePart(int from, int to, GherkinBufferSpan span, IClassificationType classificationType)
+        {
+            var textSpan = new GherkinBufferSpan(new GherkinBufferPosition(span.Buffer, span.StartPosition.Line, from), new GherkinBufferPosition(span.Buffer, span.StartPosition.Line, to));
+            ColorizeSpan(textSpan, classificationType);
+            return to;
+        }
+
         private void RegisterKeyword(string keyword, GherkinBufferSpan headerSpan)
         {
             var keywordSpan = new GherkinBufferSpan(headerSpan.StartPosition,


### PR DESCRIPTION
Related issue: https://github.com/techtalk/SpecFlow/issues/483

Notes:
- this PR is still legacy code not backed by automated tests, but I think it was worth opening to highlight what's wrong with the current implementation
- the fix may have some performance impact if there are complicated step definition patterns defined, because the regex must be matched a second time to get the correct positions
- a more correct solution would be to change `StepDefinitionMatchService.GetBestMatch` in SpecFlow to return the positions instead of substrings where possible, but that would be way over budget considering that the VS extension is using an outdated version of SpecFlow internally

Fix 1 (original issue):
Before:
![image](https://user-images.githubusercontent.com/1851369/44508858-1a453c00-a6b0-11e8-9ee3-86563d3e3788.png)

After:
![image](https://user-images.githubusercontent.com/1851369/44508835-04d01200-a6b0-11e8-9bb8-cff60966cb0e.png)

Fix 2 (multiple occurrences of the same `<pattern>`):
Before:
![image](https://user-images.githubusercontent.com/1851369/44508813-f5e95f80-a6af-11e8-9ebc-2cf7b6dca77b.png)

After:
![image](https://user-images.githubusercontent.com/1851369/44508821-fa157d00-a6af-11e8-8506-bc712acc488f.png)
