### PR TITLE
Updated app.config to ensure that assembly can be loaded for the code behind generator

### DIFF
--- a/TechTalk.SpecFlow.VisualStudio.CodeBehindGenerator/App.config
+++ b/TechTalk.SpecFlow.VisualStudio.CodeBehindGenerator/App.config
@@ -1,11 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <runtime>
+    <loadFromRemoteSources enabled="true"/>
+  </runtime>
   <configSections>
     <section name="specFlow" type="TechTalk.SpecFlow.Configuration.ConfigurationSectionHandler, TechTalk.SpecFlow" />
   </configSections>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-    </startup>
-<specFlow>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+  <specFlow>
     <!-- For additional details on SpecFlow configuration options see http://go.specflow.org/doc-config -->
-  </specFlow></configuration>
+  </specFlow>
+</configuration>


### PR DESCRIPTION
Relates to the following issue: https://github.com/techtalk/SpecFlow/issues/1337 