### PR TITLE
Add columns names to autocomplete suggestions

### DIFF
--- a/VsIntegration/AutoComplete/CompletionCommandFilter.cs
+++ b/VsIntegration/AutoComplete/CompletionCommandFilter.cs
@@ -123,6 +123,9 @@ namespace TechTalk.SpecFlow.VsIntegration.AutoComplete
             currentAutoCompleteSession.Start();
             currentAutoCompleteSession.Dismissed += (sender, args) => currentAutoCompleteSession = null;
 
+            if (currentAutoCompleteSession.SelectedCompletionSet == null)
+                return false;
+
             currentAutoCompleteSession.SelectedCompletionSet.Filter();
             currentAutoCompleteSession.SelectedCompletionSet.SelectBestMatch();
             currentAutoCompleteSession.SelectedCompletionSet.Recalculate();

--- a/VsIntegration/AutoComplete/IntellisensePresenter/CompletionSessionView.xaml
+++ b/VsIntegration/AutoComplete/IntellisensePresenter/CompletionSessionView.xaml
@@ -12,9 +12,11 @@
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="20" />
                     <ColumnDefinition />
+                    <ColumnDefinition />
                 </Grid.ColumnDefinitions>
                 <Image Source="{Binding Path=IconSource}" Height="16" Width="16" VerticalAlignment="Center" HorizontalAlignment="Center" />
                 <TextBlock Grid.Column="1" Text="{Binding Path=DisplayText, Mode=Default}" Padding="5,0,5,0" />
+                <TextBlock Grid.Column="2" Text="{Binding Path=InsertionTextColumnNames, Mode=Default}" Padding="5,0,5,0" />
             </Grid>
         </DataTemplate>
         <IntellisensePresenter:Text2Visibility x:Key="text2Visibility" />

--- a/VsIntegration/LanguageService/VsStepSuggestionProvider.cs
+++ b/VsIntegration/LanguageService/VsStepSuggestionProvider.cs
@@ -9,6 +9,7 @@ using TechTalk.SpecFlow.Infrastructure;
 using TechTalk.SpecFlow.Parser.SyntaxElements;
 using TechTalk.SpecFlow.Bindings;
 using TechTalk.SpecFlow.VsIntegration.StepSuggestions;
+using TechTalk.SpecFlow.VsIntegration.Utils;
 
 namespace TechTalk.SpecFlow.VsIntegration.LanguageService
 {
@@ -36,6 +37,21 @@ namespace TechTalk.SpecFlow.VsIntegration.LanguageService
             set
             {
                 base.IconSource = value;
+            }
+        }
+
+        public string InsertionTextColumnNames
+        {
+            get
+            {
+                var firstPipeIndex = InsertionText.IndexOf("|", StringComparison.Ordinal) + 1;
+                if (firstPipeIndex <= 0)
+                    return string.Empty;
+
+                var lastColumnNameCharIndex = StringLiteralHelper.LastIndexOfValidChar(InsertionText, new[] { ' ', '|', '\r', '\n' }) + 1;
+                var formattedColumnNames = InsertionText.Substring(firstPipeIndex, lastColumnNameCharIndex - firstPipeIndex);
+
+                return "(" + formattedColumnNames.Replace('|', ',').Trim() + ")";
             }
         }
     }

--- a/VsIntegration/Utils/StringLiteralHelper.cs
+++ b/VsIntegration/Utils/StringLiteralHelper.cs
@@ -196,5 +196,31 @@ namespace TechTalk.SpecFlow.VsIntegration.Utils
 
             return result[0];
         }
+
+        // --------------------------------------------------------------------------------
+        /// <summary>
+        /// Searches in text for the last index of a char not contained in the invalidChars array.
+        /// </summary>
+        /// <param name="text">Text in which we want to search for a char index.</param>
+        /// <param name="invalidChars">Characters we want to exclude from the index search</param>
+        /// <returns>
+        /// Zero-based index of the last char found. -1 if text or invalidChars is null, or if no char found.
+        /// </returns>
+        // --------------------------------------------------------------------------------
+        public static int LastIndexOfValidChar(string text, char[] invalidChars)
+        {
+            var lastIndex = -1;
+
+            if (string.IsNullOrEmpty(text) || invalidChars == null)
+                return lastIndex;
+
+            for (var i = 0; i < text.Length; i++)
+            {
+                if (!invalidChars.Contains(text[i]))
+                    lastIndex = i;
+            }
+
+            return lastIndex;
+        }
     }
 }


### PR DESCRIPTION
1. When displaying auto-complete suggestions, also display the column names beside it in parenthesis. 
![autocompletefix](https://user-images.githubusercontent.com/45394323/51995782-64adbe80-2481-11e9-89cb-35a461431b8b.png)

2. In CompletionCommandFilter.cs : Fix bug where trying to show autocomplete suggestions on a scenario name would give an error message ("The operation could not be completed") instead of just displaying nothing.
