### PR TITLE
Attempt to avoid dispose deadlock

### DIFF
--- a/TechTalk.SpecFlow.VsIntegration.Implementation/LanguageService/GherkinProcessingScheduler.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/LanguageService/GherkinProcessingScheduler.cs
@@ -18,12 +18,12 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.LanguageService
             this.tracer = tracer;
 
             parserQueue = new IdleTaskProcessingQueue(parsingDelay, true, tracer, DoTask);
-            parserQueue.Start();
+            parserQueue.Start("ParserQueue");
 
             if (enableAnalysis)
             {
                 analyzerQueue = new IdleTaskProcessingQueue(analyzingDelay, false, tracer, DoTask);
-                analyzerQueue.Start();
+                analyzerQueue.Start("AnalyzerQueue");
             }
         }
 


### PR DESCRIPTION
- Allow regular checking whether thread should be cancelled
- Name thread for easier debugging/diagnostics
- Set time limit to wait for thread to finish when disposing

Fixes https://github.com/techtalk/SpecFlow/issues/456