### PR TITLE
Only set AppInsightsInstrumentationKey on command-line if it has a value

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -28,4 +28,9 @@ if ($IsWindows){
 Write-Host $msbuildPath
 
 & nuget restore "./SpecFlow.VisualStudio.sln"
-& $msbuildPath ./SpecFlow.VisualStudio.sln -property:Configuration=$Configuration -binaryLogger:msbuild.$Configuration.binlog -nodeReuse:false "-property:AppInsightsInstrumentationKey=$appInsightsInstrumentationKey"
+
+if ($appInsightsInstrumentationKey) {
+  $extraArgs = "-property:AppInsightsInstrumentationKey=$appInsightsInstrumentationKey"
+}
+
+& $msbuildPath ./SpecFlow.VisualStudio.sln -property:Configuration=$Configuration -binaryLogger:msbuild.$Configuration.binlog -nodeReuse:false $extraArgs


### PR DESCRIPTION
Fixes https://github.com/techtalk/SpecFlow/issues/1632