### PR TITLE
Fix reset of legacy 'Enable SpecFlowSingleFileGeneratorCustomTool' setting

### DIFF
--- a/TechTalk.SpecFlow.VSIXShared/Options/IntegrationOptionsProvider.cs
+++ b/TechTalk.SpecFlow.VSIXShared/Options/IntegrationOptionsProvider.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.ComponentModel.Composition;
-using System.Linq;
+﻿using System.ComponentModel.Composition;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using TechTalk.SpecFlow.IdeIntegration.Options;
@@ -16,7 +14,6 @@ namespace TechTalk.SpecFlow.VsIntegration.Options
 
         public const string SPECFLOW_OPTIONS_CATEGORY = "SpecFlow";
         public const string SPECFLOW_GENERAL_OPTIONS_PAGE = "General";
-
 
         private DTE dte;
 
@@ -67,7 +64,8 @@ namespace TechTalk.SpecFlow.VsIntegration.Options
                 StepIndent = GetGeneralOption(dte, "StepIndent", OptionDefaultValues.DefaultStepIndent),
                 TableIndent = GetGeneralOption(dte, "TableIndent", OptionDefaultValues.DefaultTableIndent),
                 MultilineIndent = GetGeneralOption(dte, "MultilineIndent", OptionDefaultValues.DefaultMultilineIndent),
-                ExampleIndent = GetGeneralOption(dte, "ExampleIndent", OptionDefaultValues.DefaultExampleIndent)
+                ExampleIndent = GetGeneralOption(dte, "ExampleIndent", OptionDefaultValues.DefaultExampleIndent),
+                LegacyEnableSpecFlowSingleFileGeneratorCustomTool = GetGeneralOption(dte, "LegacyEnableSpecFlowSingleFileGeneratorCustomTool", OptionDefaultValues.LegacyEnableSpecFlowSingleFileGeneratorCustomTool)
             };
             cachedOptions = options;
             return options;
@@ -78,7 +76,6 @@ namespace TechTalk.SpecFlow.VsIntegration.Options
         {
             set { dte = VsxHelper.GetDte(value); }
         }
-
 
         public IntegrationOptions GetOptions()
         {

--- a/TechTalk.SpecFlow.VsIntegration.Implementation/Options/OptionDefaultValues.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/Options/OptionDefaultValues.cs
@@ -28,5 +28,6 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.Options
         public const int DefaultTableIndent = 2;
         public const int DefaultMultilineIndent = 2;
         public const int DefaultExampleIndent = 1;
+        public const bool LegacyEnableSpecFlowSingleFileGeneratorCustomTool = false;
     }
 }

--- a/TechTalk.SpecFlow.VsIntegration.Implementation/Options/OptionsPageGeneral.cs
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/Options/OptionsPageGeneral.cs
@@ -9,8 +9,8 @@ using TechTalk.SpecFlow.VsIntegration.Implementation.SingleFileGenerator;
 namespace TechTalk.SpecFlow.VsIntegration.Implementation.Options
 {
     /// <summary>
-    // Extends a standard dialog functionality for implementing ToolsOptions pages, 
-    // with support for the Visual Studio automation model, Windows Forms, and state 
+    // Extends a standard dialog functionality for implementing ToolsOptions pages,
+    // with support for the Visual Studio automation model, Windows Forms, and state
     // persistence through the Visual Studio settings mechanism.
     /// </summary>
     [Guid("D41B81C9-8501-4124-B75F-0F194E37178C")]
@@ -69,7 +69,6 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.Options
         [DefaultValue(OptionDefaultValues.EnableTableAutoFormatDefaultValue)]
         public bool EnableTableAutoFormat { get; set; }
 
-
         [Category("IntelliSense")]
         [Description("Controls whether completion lists should be displayed for the feature files.")]
         [DisplayName(@"Enable IntelliSense")]
@@ -77,6 +76,7 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.Options
         public bool EnableIntelliSense { get; set; }
 
         private string _maxStepInstancesSuggestions = String.Empty;
+
         [Category("IntelliSense")]
         [Description("Limit quantity of IntelliSense step instances suggestions for each step template.")]
         [DisplayName(@"Max Step Instances Suggestions")]
@@ -110,7 +110,6 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.Options
         [DefaultValue(OptionDefaultValues.TracingCategoriesDefaultValue)]
         public string TracingCategories { get; set; }
 
-
         [Category("Code Behind File Generation")]
         [Description("Specifies the mode how the code behind file is generated")]
         [DisplayName("Generation Mode")]
@@ -129,12 +128,12 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.Options
         [DefaultValue(OptionDefaultValues.CodeBehindFileGeneratorPath)]
         public string CodeBehindFileGeneratorExchangePath { get; set; }
 
-
         [Category("Legacy")]
         [Description("Enables code-behind file generation via CustomTool. Turn off when you use the MSBuild integration.")]
         [DisplayName("Enable SpecFlowSingleFileGenerator CustomTool")]
         [DefaultValue(false)]
         public bool LegacyEnableSpecFlowSingleFileGeneratorCustomTool { get; set; }
+
         public const string UsageStatisticsCategory = "Usage statistics";
 
         [Category(UsageStatisticsCategory)]
@@ -223,7 +222,7 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.Options
             PathToCodeBehindGeneratorExe = OptionDefaultValues.CodeBehindFileGeneratorPath;
             CodeBehindFileGeneratorExchangePath = OptionDefaultValues.CodeBehindFileGeneratorExchangePath;
             OptOutDataCollection = OptionDefaultValues.DefaultOptOutDataCollection;
-            LegacyEnableSpecFlowSingleFileGeneratorCustomTool = _customToolSwitch.IsEnabled();
+            LegacyEnableSpecFlowSingleFileGeneratorCustomTool = OptionDefaultValues.LegacyEnableSpecFlowSingleFileGeneratorCustomTool;
             NormalizeLineBreaks = OptionDefaultValues.NormalizeLineBreaksDefaultValue;
             LineBreaksBeforeScenario = OptionDefaultValues.DefaultLineBreaksBeforeScenario;
             LineBreaksBeforeExamples = OptionDefaultValues.DefaultLineBreaksBeforeExamples;
@@ -239,18 +238,23 @@ namespace TechTalk.SpecFlow.VsIntegration.Implementation.Options
         public override void LoadSettingsFromStorage()
         {
             base.LoadSettingsFromStorage();
-            LegacyEnableSpecFlowSingleFileGeneratorCustomTool = _customToolSwitch.IsEnabled();
+            ToggleCustomToolSwitch();
         }
 
         public override void SaveSettingsToStorage()
         {
             base.SaveSettingsToStorage();
+            ToggleCustomToolSwitch();
+        }
 
-            if (LegacyEnableSpecFlowSingleFileGeneratorCustomTool)
+        private void ToggleCustomToolSwitch()
+        {
+            var isCustomToolSwitchEnabled = _customToolSwitch.IsEnabled();
+            if (LegacyEnableSpecFlowSingleFileGeneratorCustomTool && !isCustomToolSwitchEnabled)
             {
                 _customToolSwitch.Enable();
             }
-            else
+            else if (!LegacyEnableSpecFlowSingleFileGeneratorCustomTool && isCustomToolSwitchEnabled)
             {
                 _customToolSwitch.Disable();
             }


### PR DESCRIPTION
This is done by separating registry registration of the single file generator and the VS extension option preference.

Registering the single file generator in the registry is still necessary I believe, see [Registering Single File Generators](https://docs.microsoft.com/en-us/visualstudio/extensibility/internals/registering-single-file-generators?view=vs-2019) over at Microsoft Docs. 

I also changed the default setting to `false`, which seems only logical for a legacy setting.

Resolves https://github.com/techtalk/SpecFlow/issues/1584.

I found it quite hard to test, but it seems to be working alright. Could you do an extensive test as well? Thanks!