### PR TITLE
Use instrumentation key of the "common" resource group for testing

### DIFF
--- a/TechTalk.SpecFlow.VsIntegration.Implementation/TechTalk.SpecFlow.VsIntegration.Implementation.csproj
+++ b/TechTalk.SpecFlow.VsIntegration.Implementation/TechTalk.SpecFlow.VsIntegration.Implementation.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(AppInsightsInstrumentationKey)' == ''">
     <!-- This is only the testing instance's instrumentation key -->
-    <AppInsightsInstrumentationKey>88c7861a-5106-4d48-b545-b26ee23e1f21</AppInsightsInstrumentationKey>
+    <AppInsightsInstrumentationKey>27cfb992-6c29-4bc8-8093-78d95e275b3a</AppInsightsInstrumentationKey>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Analytics\AppInsightsInstrumentationKey.template.cs" />


### PR DESCRIPTION
We should use the InstrumentationKey of an Application Insights which is accessible for everyone.
I already created a resource group @ Azure - we should use that for **testing** (instead of David's resource group) 
Details can be found in OneNote.