### PR TITLE
remove registration of CustomTool via attributes

### DIFF
--- a/TechTalk.SpecFlow.VSIXShared/SpecFlowSingleFileGenerator.cs
+++ b/TechTalk.SpecFlow.VSIXShared/SpecFlowSingleFileGenerator.cs
@@ -17,9 +17,6 @@ namespace TechTalk.SpecFlow.VsIntegration
 {
     [ComVisible(true)]
     [Guid("44F8C2E2-18A9-4B97-B830-6BCD0CAA161C")]
-    [CodeGeneratorRegistrationWithFileExtension(typeof(SpecFlowSingleFileGenerator), "C# SpecFlow Generator", "{9A19103F-16F7-4668-BE54-9A1E7A4F7556}", GeneratesDesignTimeSource = true, FileExtension = ".feature")]
-    [CodeGeneratorRegistrationWithFileExtension(typeof(SpecFlowSingleFileGenerator), "C# SpecFlow Generator", vsContextGuids.vsContextGuidVCSProject, GeneratesDesignTimeSource = true, FileExtension = ".feature")]
-    [CodeGeneratorRegistrationWithFileExtension(typeof(SpecFlowSingleFileGenerator), "VB.NET SpecFlow Generator", vsContextGuids.vsContextGuidVBProject, GeneratesDesignTimeSource = true, FileExtension = ".feature")]
     [ProvideObject(typeof(SpecFlowSingleFileGenerator))]
     public class SpecFlowSingleFileGenerator : SpecFlowSingleFileGeneratorBase
     {


### PR DESCRIPTION
Because the Custom Tool is registered via attributes, it enabled at the first startup after installing or updating the VS extension. It was disabled the launches after the first start.
Removing the attributes fixes this unintended behavior.
